### PR TITLE
Show/Hide feedback menu bar option basis of Auth

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/PluginUtils.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/PluginUtils.java
@@ -13,6 +13,7 @@ import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.ui.PlatformUI;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 


### PR DESCRIPTION
Display or Hide the Share Feedback button in the menu bar based on authentication state. If user is login, then it needs to be shown, otherwise hidden. 
-- Unrelated: added a missing import to PluginUtils class
-- Tracking ticket: https://issues.amazon.com/issues/ECLIPSE-277

**Testing**
- Verified the Share Feedback is not shown when the extension opens in Sign Out stage. 
- Verified the Share Feedback is present when the extension opens in Sign In/Login stage. 
- Verified the Share Feedback is not shown when the extension opens in Sign Out stage and it starts to display once user signs it from here.
- Verified the Share Feedback is shown when the extension opens in Sign In/Login stage and it is hidden once user signs out from here.