### PR TITLE
Parse params from command request

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatViewActionHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatViewActionHandler.java
@@ -1,0 +1,30 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.views;
+
+
+import org.eclipse.swt.browser.Browser;
+
+import software.aws.toolkits.eclipse.amazonq.util.PluginLogger;
+import software.aws.toolkits.eclipse.amazonq.views.model.ParsedCommand;
+
+public class AmazonQChatViewActionHandler implements ViewActionHandler {
+    @Override
+    public final void handleCommand(ParsedCommand parsedCommand, final Browser browser) {
+        switch (parsedCommand.getCommand()) {
+            case CHAT_READY:
+                PluginLogger.info("Chat_ready command received");
+                break;
+            case CHAT_TAB_ADD:
+                PluginLogger.info("Chat_tab_add command received with params " + parsedCommand.getParams().toString());
+                break;
+            case TELEMETRY_EVENT:
+            	PluginLogger.info("Telemetry command received with params " + parsedCommand.getParams().toString());
+                break;
+            default:
+                PluginLogger.info("Unhandled command: " + parsedCommand.getCommand());
+                break;
+        }
+    }
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
@@ -44,7 +44,7 @@ public class AmazonQChatWebview extends ViewPart implements ISelectionListener {
 
     public AmazonQChatWebview() {
         this.commandParser = new LoginViewCommandParser();
-        this.actionHandler = new LoginViewActionHandler();
+        this.actionHandler = new AmazonQChatViewActionHandler();
     }
 
     @Override
@@ -64,14 +64,15 @@ public class AmazonQChatWebview extends ViewPart implements ISelectionListener {
         contributeToActionBars(getViewSite());
         getSite().getPage().addSelectionListener(this);
 
-       new BrowserFunction(browser, "clientApi") {
+       new BrowserFunction(browser, "ideCommand") {
             @Override
             public Object function(final Object[] arguments) {
                 commandParser.parseCommand(arguments)
-                        .ifPresent(command -> actionHandler.handleCommand(command, browser));
+                        .ifPresent(parsedCommand -> actionHandler.handleCommand(parsedCommand, browser));
                 return null;
             }
         };
+        
     }
 
     private void contributeToActionBars(final IViewSite viewSite) {
@@ -168,7 +169,11 @@ public class AmazonQChatWebview extends ViewPart implements ISelectionListener {
         return String.format("<script type=\"text/javascript\" src=\"%s\" defer onload=\"init()\"></script>\n"
                 + "    <script type=\"text/javascript\">\n"
                 + "        const init = () => {\n"
-                + "            amazonQChat.createChat(clientApi());\n"
+                + "            amazonQChat.createChat({\n"
+                + "               postMessage: (message) => {\n"
+                + "                    ideCommand(JSON.stringify(message));\n"
+                + "               }\n"			
+                + "			});\n"
                 + "        }\n"
                 + "    </script>", jsEntrypoint);
     }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/LoginViewActionHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/LoginViewActionHandler.java
@@ -3,18 +3,19 @@
 
 package software.aws.toolkits.eclipse.amazonq.views;
 
+
 import org.eclipse.swt.browser.Browser;
 import org.eclipse.swt.widgets.Display;
 
 import software.aws.toolkits.eclipse.amazonq.util.AuthUtils;
 import software.aws.toolkits.eclipse.amazonq.util.PluginLogger;
 import software.aws.toolkits.eclipse.amazonq.util.ThreadingUtils;
-import software.aws.toolkits.eclipse.amazonq.views.model.Command;
+import software.aws.toolkits.eclipse.amazonq.views.model.ParsedCommand;
 
 public class LoginViewActionHandler implements ViewActionHandler {
     @Override
-    public final void handleCommand(final Command command, final Browser browser) {
-        switch (command) {
+    public final void handleCommand(final ParsedCommand parsedCommand, final Browser browser) {
+        switch (parsedCommand.getCommand()) {
             case LOGIN_BUILDER_ID:
                 PluginLogger.info("loginBuilderId command received");
                 ThreadingUtils.executeAsyncTask(() -> {
@@ -30,7 +31,7 @@ public class LoginViewActionHandler implements ViewActionHandler {
                 PluginLogger.info("cancelLogin command received");
                 break;
             default:
-                System.out.println("Unknown command: " + command);
+                System.out.println("Unknown command: " + parsedCommand.getCommand());
                 break;
         }
     }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/LoginViewCommandParser.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/LoginViewCommandParser.java
@@ -10,8 +10,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import software.aws.toolkits.eclipse.amazonq.util.ObjectMapperFactory;
 import software.aws.toolkits.eclipse.amazonq.util.PluginLogger;
-import software.aws.toolkits.eclipse.amazonq.views.model.Command;
 import software.aws.toolkits.eclipse.amazonq.views.model.CommandRequest;
+import software.aws.toolkits.eclipse.amazonq.views.model.ParsedCommand;
 
 public class LoginViewCommandParser implements ViewCommandParser {
     private final ObjectMapper objectMapper;
@@ -21,12 +21,12 @@ public class LoginViewCommandParser implements ViewCommandParser {
     }
 
     @Override
-    public final Optional<Command> parseCommand(final Object[] arguments) {
+    public final Optional<ParsedCommand> parseCommand(final Object[] arguments) {
         if (arguments.length > 0 && arguments[0] instanceof String) {
             String jsonString = (String) arguments[0];
             try {
                 CommandRequest commandRequest = objectMapper.readValue(jsonString, CommandRequest.class);
-                return Optional.ofNullable(commandRequest.getCommand());
+                return commandRequest.getParsedCommand();
             } catch (JsonProcessingException e) {
                 PluginLogger.error("Error parsing webview command JSON: " + e.getMessage());
             }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/ViewActionHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/ViewActionHandler.java
@@ -5,8 +5,8 @@ package software.aws.toolkits.eclipse.amazonq.views;
 
 import org.eclipse.swt.browser.Browser;
 
-import software.aws.toolkits.eclipse.amazonq.views.model.Command;
+import software.aws.toolkits.eclipse.amazonq.views.model.ParsedCommand;
 
 public interface ViewActionHandler {
-    void handleCommand(Command command, Browser browser);
+    void handleCommand(ParsedCommand parsedCommand, Browser browser);
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/ViewCommandParser.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/ViewCommandParser.java
@@ -5,8 +5,8 @@ package software.aws.toolkits.eclipse.amazonq.views;
 
 import java.util.Optional;
 
-import software.aws.toolkits.eclipse.amazonq.views.model.Command;
+import software.aws.toolkits.eclipse.amazonq.views.model.ParsedCommand;
 
 public interface ViewCommandParser {
-    Optional<Command> parseCommand(Object[] arguments);
+    Optional<ParsedCommand> parseCommand(Object[] arguments);
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/Command.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/Command.java
@@ -3,10 +3,19 @@
 
 package software.aws.toolkits.eclipse.amazonq.views.model;
 
+import java.util.Optional;
+
+import software.aws.toolkits.eclipse.amazonq.util.PluginLogger;
+
 public enum Command {
+	// QChat 
+	CHAT_READY("aws/chat/ready"),
+	CHAT_TAB_ADD("aws/chat/tabAdd"),
+	TELEMETRY_EVENT("telemetry/event"),
+	
+	// Auth
     LOGIN_BUILDER_ID("loginBuilderId"),
-    CANCEL_LOGIN("cancelLogin"),
-    UKNOWN("unknown");
+    CANCEL_LOGIN("cancelLogin");
 
     private final String commandString;
 
@@ -14,12 +23,14 @@ public enum Command {
         this.commandString = commandString;
     }
 
-    public static Command fromString(final String value) {
+    public static Optional<Command> fromString(final String value) {
         for (Command command : Command.values()) {
             if (command.commandString.equals(value)) {
-                return command;
+                return Optional.ofNullable(command);
             }
         }
-        return Command.UKNOWN;
+        
+        PluginLogger.info("Unregistered command parsed: " + value);
+        return Optional.empty();
     }
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/CommandRequest.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/CommandRequest.java
@@ -2,11 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package software.aws.toolkits.eclipse.amazonq.views.model;
+import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record CommandRequest(@JsonProperty("command") String commandString) {
-    public Command getCommand() {
-        return Command.fromString(commandString);
+public record CommandRequest(
+		    @JsonProperty("command") String commandString, 
+		    @JsonProperty("params") Object params) 
+	{
+    public Optional<ParsedCommand> getParsedCommand() {
+        Optional<Command> command = Command.fromString(commandString);
+        
+        if (!command.isPresent()) {
+        	return Optional.empty();
+        }
+        
+        ParsedCommand parsedCommand = new ParsedCommand(command.get(), Optional.ofNullable(params));
+        return Optional.ofNullable(parsedCommand);
     }
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/ParsedCommand.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/ParsedCommand.java
@@ -1,0 +1,25 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+package software.aws.toolkits.eclipse.amazonq.views.model;
+
+import java.util.Optional;
+
+public class ParsedCommand {
+
+    private final Command command;
+	private final Object params;
+
+	public ParsedCommand(Command command, Optional<Object> params) {
+        this.command = command;
+        this.params = params;
+	}
+	
+	public Command getCommand() {
+		return this.command;
+	}
+	
+	public Object getParams() {
+		return this.params;
+	}
+
+}


### PR DESCRIPTION
# Description
- Updated the initiation of the Q Chat client to `postMessage` using the Eclipse command parser
- Upon opening the Q Chat client, I noticed that the commands coming from the UI client also provides params. Therefore, I added a ParsedCommand class that acts as a container for a Command and Params Object. 
   - I replaced the usage of Command with ParsedCommand.getCommand()
- I updated the logging to more accurately identify unknown commands
   - If a command is not registered in the Command class, you will see a "Unregistered command parsed: {command}" message
   - If a command is not handled by the Handler class, you will see a "Unhandled command: {command}" message

## Demo of "params" parsing

https://github.com/user-attachments/assets/9e7bd800-b23b-4b14-98c3-97a3b5c60c82

## Demo of existing behavior still working

https://github.com/user-attachments/assets/d1679313-a8ec-42f3-b894-dbba32638f27



