### PR TITLE
Display chat default message and prompt

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
@@ -156,12 +156,15 @@ public class AmazonQChatWebview extends ViewPart implements ISelectionListener {
                 + "        html {\n"
                 + "            background-color: var(--mynah-color-bg);\n"
                 + "            color: var(--mynah-color-text-default);\n"
-                + "            height: 100%%;\n"
+                + "            height: 100vh;\n"
                 + "            width: 100%%;\n"
                 + "            overflow: hidden;\n"
                 + "            margin: 0;\n"
                 + "            padding: 0;\n"
                 + "        }\n"
+                + "        textarea:placeholder-shown {\n"
+                + "            line-height: 1.5rem;\n"
+                + "        }"
                 + "    </style>";
     }
 


### PR DESCRIPTION
## Description:
- Previously, when opening Chat, no default message or chat prompt was displayed. See the following image:
<img width="1196" alt="Screenshot 2024-09-16 at 3 37 59 PM" src="https://github.com/user-attachments/assets/cbfcd82b-d26b-43e5-95c0-7b12ef46b965">
- Identified an issue with the CS being being incorrectly configured for the height (my assumption is the message and prompt were rendering but not being displayed in view.

## Demo of Default message and Prompt

https://github.com/user-attachments/assets/6b77f9f0-bf2a-4b27-8f0b-dd87f5e9de49



