### PR TITLE
Adds step to upload and download build artifacts

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,6 +29,11 @@ jobs:
       run: |
         cd plugin/webview
         npm run build-ui  
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: build-ui-artifacts
+        path: plugin/webview/build/
     - name: Setup Maven Action
       uses: s4u/setup-maven-action@v1.14.0
       with:
@@ -36,5 +41,10 @@ jobs:
         java-version: 17
         java-distribution: temurin
         maven-version: 3.9.8
+    - name: Download build artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: build-ui-artifacts
+        path: plugin/webview/build
     - name: Build with Maven
       run: mvn -B package --file pom.xml


### PR DESCRIPTION
## Premise
CI step `Build with maven` has been failing with the following message: 
```bash
Error:  Failed to execute goal org.eclipse.tycho:tycho-packaging-plugin:4.0.8:package-plugin (default-package-plugin) on project amazon-q-eclipse: /home/runner/work/amazon-q-eclipse/amazon-q-eclipse/plugin/build.properties: bin.includes value(s) [webview/build/] do not match any files. -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
Error:  
Error:  After correcting the problems, you can resume the build with the command
Error:    mvn <args> -rf :amazon-q-eclipse
Error: Process completed with exit code 1.
```

Changes: 
- Added a step to upload the build artifact after webview `npm install & npm run webpack`.
- Added a step to download the aforementioned build artifacts prior to step `Build with maven`. 

## Test
CI passes. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
