### PR TITLE
Notifications helper to show notifications

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/NotificationType.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/NotificationType.java
@@ -1,8 +1,0 @@
-// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-package software.aws.toolkits.eclipse.amazonq.util;
-
-public enum NotificationType {
-    CUSTOMIZATION_CHANGED
-}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/ToolkitNotification.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/ToolkitNotification.java
@@ -16,26 +16,27 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.mylyn.commons.ui.dialogs.AbstractNotificationPopup;
 
-public final class NotificationHelper extends AbstractNotificationPopup {
+public final class ToolkitNotification extends AbstractNotificationPopup {
 
     private final String title;
     private final String description;
-    private final NotificationType notificationType;
+    private Image infoIcon;
 
-    public NotificationHelper(final Display display, final String title, final String description, final NotificationType notificationType) {
+    public ToolkitNotification(final Display display, final String title, final String description) {
         super(display);
         this.title = title;
         this.description = description;
-        this.notificationType = notificationType;
     }
 
     private Image getInfoIcon() {
         ISharedImages sharedImages = PlatformUI.getWorkbench().getSharedImages();
         ImageDescriptor imageDescriptor = sharedImages.getImageDescriptor(ISharedImages.IMG_OBJS_INFO_TSK);
-        return imageDescriptor.createImage();
+        this.infoIcon = imageDescriptor.createImage();
+        return this.infoIcon;
     }
 
-    private void showStandardNotification(final Composite parent) {
+    @Override
+    protected void createContentArea(final Composite parent) {
         Composite container = new Composite(parent, SWT.NONE);
         container.setLayout(new GridLayout(2, false));
         container.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
@@ -50,13 +51,6 @@ public final class NotificationHelper extends AbstractNotificationPopup {
     }
 
     @Override
-    protected void createContentArea(final Composite parent) {
-        if (this.notificationType.equals(NotificationType.CUSTOMIZATION_CHANGED)) {
-            showStandardNotification(parent);
-        }
-    }
-
-    @Override
     protected String getPopupShellTitle() {
         return this.title;
     }
@@ -64,5 +58,13 @@ public final class NotificationHelper extends AbstractNotificationPopup {
     @Override
     protected Point getInitialSize() {
         return new Point(60, 20);
+    }
+
+    @Override
+    public boolean close() {
+        if (this.infoIcon != null && !this.infoIcon.isDisposed()) {
+            this.infoIcon.dispose();
+        }
+        return super.close();
     }
 }


### PR DESCRIPTION
Reference ticket: https://issues.amazon.com/issues/ECLIPSE-293 

The PR aims to create a common place to get the notifications displayed on some plugin actions. One of the first use cases where notifications will be required is the Customization use case, where we display a notification to the user once the selection of the customization is performed. The current PR does not aim at integrating this code with the logic where we wish to display the same (that will be done when the logic is implemented)

However, for local testing - this is how i used the newly created notification helper functionality. 
`final String message = "Amazon Q inline suggestions are now coming from the Amazon-Internal-V1 customization";
AbstractNotificationPopup notification = new NotificationHelper(Display.getCurrent(), "Amazon Q Customization", message, NotificationType.CUSTOMIZATION_CHANGED);
notification.open();`

Attaching a screenshot for the same: 

<img width="435" alt="Notification-Eclipse" src="https://github.com/user-attachments/assets/b6dd6e41-951b-4b6a-9159-8723c779e749">

