### PR TITLE
Fix to allow only one radio button to be selected

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/FeedbackDialog.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/FeedbackDialog.java
@@ -213,8 +213,22 @@ public class FeedbackDialog extends Dialog {
         RowLayout sentimentContainerLayout = new RowLayout(SWT.HORIZONTAL);
         sentimentContainerLayout.spacing = 0;
         sentimentContainer.setLayout(sentimentContainerLayout);
-        createCustomRadioButton(sentimentContainer, "icons/HappyFace.png", "Satisfied", SWT.NONE, true);
-        createCustomRadioButton(sentimentContainer, "icons/FrownyFace.png", "Unsatisfied", SWT.NONE, false);
+        CustomRadioButton positiveSentimentButton = createCustomRadioButton(sentimentContainer, "icons/HappyFace.png", "Satisfied", SWT.NONE, true);
+        CustomRadioButton negativeSentimentButton = createCustomRadioButton(sentimentContainer, "icons/FrownyFace.png", "Unsatisfied", SWT.NONE, false);
+        positiveSentimentButton.getRadioButton().addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+            	negativeSentimentButton.getRadioButton().setSelection(false);
+            	selectedSentiment = Sentiment.POSITIVE;
+            }
+        });
+        negativeSentimentButton.getRadioButton().addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+            	positiveSentimentButton.getRadioButton().setSelection(false);
+            	selectedSentiment = Sentiment.NEGATIVE;
+            }
+        });
 
         createLabel(questionsContainer, "What do you like about the AWS Toolkit? What can we improve?");
 
@@ -266,15 +280,10 @@ public class FeedbackDialog extends Dialog {
         separatorLabel.setLayoutData(separatorGithubLayout);
     }
 
-    private void createCustomRadioButton(final Composite parent, final String imagePath, final String text, final int style, final boolean isSelected) {
+    private CustomRadioButton createCustomRadioButton(final Composite parent, final String imagePath, final String text, final int style, final boolean isSelected) {
         CustomRadioButton button = new CustomRadioButton(parent, loadImage(imagePath), text, style);
         button.getRadioButton().setSelection(isSelected);
-        button.getRadioButton().addSelectionListener(new SelectionAdapter() {
-            @Override
-            public void widgetSelected(final SelectionEvent e) {
-                // Handle button selection
-            }
-        });
+        return button;
     }
 
     private String getBodyMessageForReportIssueOrRequestFeature() {


### PR DESCRIPTION
Reference ticket: https://issues.amazon.com/issues/ECLIPSE-298 

During some refactoring, the onWidgetSelection listener of the radio buttons was accidentally removed(representing Positive and Negative sentiments), which allowed both radio buttons to be selected simultaneously. 

The PR aims to fix that, which would allow only one radio button to be selected at a time and hence setting the correct selected sentiment state. WidgetListeners for each radio button can be and mostly be different only, so extracting the same out of the common method which creates custom radio buttons. 

The changes have been tested on local and working smooth. 