### PR TITLE
Fix Chat webview rendering

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
@@ -77,7 +77,7 @@ public class AmazonQChatWebview extends AmazonQView {
                     <meta
                         http-equiv="Content-Security-Policy"
                         content="default-src 'none'; script-src %s 'unsafe-inline'; style-src %s 'unsafe-inline';
-                        img-src 'self' data:; object-src 'none'; base-uri 'none'; upgrade-insecure-requests;"
+                        img-src 'self' data:; object-src 'none'; base-uri 'none';"
                     >
                     <title>Chat UI</title>
                     %s


### PR DESCRIPTION
*Description of changes:*
- Q Chat View is unable to load the `amazonq-ui.js` resource 
- I suspect `upgrade-insecure-requests` flag to be transforming the `http` request to a secure `https` request where the resource is not found
  - Expected: `http://localhost:59408/amazonq-ui.js`
  - Actual: `https://localhost:59408/amazonq-ui.js`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
