### PR TITLE
Update .checkstyle to use local config

### DIFF
--- a/plugin/.checkstyle
+++ b/plugin/.checkstyle
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
-  <fileset name="all" enabled="true" check-config-name="Copy of Sun Checks" local="false">
-    <file-match-pattern match-pattern="." include-pattern="true"/>
+  <local-check-config name="Eclipse Q" location="/checkstyle.xml" type="project" description="">
+    <additional-data name="protect-config-file" value="false"/>
+  </local-check-config>
+  <fileset name="all" enabled="true" check-config-name="Eclipse Q" local="true">
+    <file-match-pattern match-pattern="^src/.*" include-pattern="true"/>
   </fileset>
 </fileset-config>


### PR DESCRIPTION
*Description of changes:*
Configures the Eclipse CS plugin to use the project local `checkstyle.xml`, as well as only including files under `src/` to avoid generated sources getting flagged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
