### PR TITLE
Support cancelling in-flight chat requests when tab is removed

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatMessageProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatMessageProvider.java
@@ -16,7 +16,8 @@ import software.aws.toolkits.eclipse.amazonq.providers.LspProvider;
 public final class ChatMessageProvider {
 
     private final AmazonQLspServer amazonQLspServer;
-    // Map of in-flight requests per tab Id
+    // Map of in-flight requests per tab Ids
+    // TODO ECLIPSE-349: Handle disposing resources of this class including this map
     private Map<String, CompletableFuture<ChatResult>> inflightRequestByTabId = new ConcurrentHashMap<String, CompletableFuture<ChatResult>>();
 
     public static CompletableFuture<ChatMessageProvider> createAsync() {


### PR DESCRIPTION
*Description of changes:*
Follow-up to PR #60. 
Adds handling for cancelling any in-flight chat requests sent to the language server when a tab is removed.
Added a TODO to handle disposal of the inflight request map and other resources related to chat when a chat session ends(when user connection expires, user closes eclipse or disables q)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
