### PR TITLE
Update dependency sync to correctly target built classes

### DIFF
--- a/plugin/build/syncDependencies.sh
+++ b/plugin/build/syncDependencies.sh
@@ -19,7 +19,7 @@ if [ ! -f "$manifest_file" ]; then
 fi
 
 # Initialize the Bundle-Classpath entry
-bundle_classpath="Bundle-Classpath: .,\n"
+bundle_classpath="Bundle-Classpath: target/classes/,\n"
 
 # Loop through the JAR files in the dependency directory
 for jar in "$dependency_dir"/*.jar; do


### PR DESCRIPTION
*Description of changes:*
Without this, built plugin classes are not loaded when the plugin is run standalone.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
