### PR TITLE
Excluding Builder classes from test coverage

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -280,6 +280,10 @@
                             <includes>
                                 <include>software/aws/toolkits/eclipse/amazonq/**</include>
                             </includes>
+                            <excludes>
+                                <exclude>**/*$Builder.class</exclude>
+                                <exclude>**/Builder.class</exclude>
+                            </excludes>
                         </configuration>
                     </execution>
                     <execution>
@@ -291,6 +295,10 @@
                             <includes>
                                 <include>software/aws/toolkits/eclipse/amazonq/**</include>
                             </includes>
+                            <excludes>
+                                <exclude>**/*$Builder.class</exclude>
+                                <exclude>**/Builder.class</exclude>
+                            </excludes>
                             <rules>
                                 <rule>
                                     <element>BUNDLE</element>


### PR DESCRIPTION
*Description of changes:*
* Added exclusion rule to pom.xml in order to remove any Builders from the test coverage calculations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
