### PR TITLE
Use file path uri when making inline completion request

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/InlineCompletionUtils.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/InlineCompletionUtils.java
@@ -24,12 +24,12 @@ public final class InlineCompletionUtils {
         System.out.println("Param made with invocation offset of " + invocationOffset);
         var document = viewer.getDocument();
 
-        var openFilePath = QEclipseEditorUtils.getOpenFilePath(editor.getEditorInput());
+        var openFileUri = QEclipseEditorUtils.getOpenFileUri(editor.getEditorInput());
 
         var params = new InlineCompletionParams();
-        var identifier = new TextDocumentIdentifier();
-        identifier.setUri("file://" + openFilePath);
-        params.setTextDocument(identifier);
+        openFileUri.ifPresent(filePathUri -> {
+            params.setTextDocument(new TextDocumentIdentifier(filePathUri));
+        });
 
         var inlineCompletionContext = new InlineCompletionContext();
         inlineCompletionContext.setTriggerKind(triggerKind);

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QEclipseEditorUtils.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QEclipseEditorUtils.java
@@ -107,6 +107,17 @@ public final class QEclipseEditorUtils {
         }
     }
 
+    public static Optional<String> getOpenFileUri(final IEditorInput editorInput) {
+        try {
+            var filePath = getOpenFilePath(editorInput);
+            var fileUri = Paths.get(filePath).toUri().toString();
+            return Optional.of(fileUri);
+        } catch (Exception e) {
+            Activator.getLogger().error("Unexpected error when determining open file path", e);
+            return Optional.empty();
+        }
+    }
+
     private static Optional<String> getOpenFilePath() {
         var editor = getActiveTextEditor();
         if (editor == null) {


### PR DESCRIPTION
*Description of changes:*
Use file path uri that constructs the uri in a platform agnostic way. The old way was incompatible with Windows systems

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
