### PR TITLE
Makes insert position account for folded lines

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/handlers/QAcceptSuggestionsHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/handlers/QAcceptSuggestionsHandler.java
@@ -8,6 +8,7 @@ import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.ITextViewerExtension5;
 import org.eclipse.swt.widgets.Display;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
 import software.aws.toolkits.eclipse.amazonq.util.QInvocationSession;
@@ -38,9 +39,14 @@ public class QAcceptSuggestionsHandler extends AbstractHandler {
             IDocument doc = viewer.getDocument();
             var widget = viewer.getTextWidget();
             var insertOffset = widget.getCaretOffset();
+            int adjustedOffset = insertOffset;
+            if (viewer instanceof ITextViewerExtension5) {
+                ITextViewerExtension5 extension = (ITextViewerExtension5) viewer;
+                adjustedOffset = extension.widgetOffset2ModelOffset(insertOffset);
+            }
             int startIdx = widget.getCaretOffset() - qSes.getInvocationOffset();
             String adjustedSuggestion = suggestion.substring(startIdx);
-            doc.replace(insertOffset, 0, adjustedSuggestion);
+            doc.replace(adjustedOffset, 0, adjustedSuggestion);
             widget.setCaretOffset(insertOffset + adjustedSuggestion.length());
             QInvocationSession.getInstance().getViewer().getTextWidget().redraw();
             QInvocationSession.getInstance().executeCallbackForCodeReference();

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/InlineCompletionUtils.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/InlineCompletionUtils.java
@@ -5,6 +5,7 @@ package software.aws.toolkits.eclipse.amazonq.util;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.ITextViewerExtension5;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.ui.texteditor.ITextEditor;
@@ -37,8 +38,13 @@ public final class InlineCompletionUtils {
         params.setContext(inlineCompletionContext);
 
         var invocationPosition = new Position();
-        var startLine = document.getLineOfOffset(invocationOffset);
-        var lineOffset = invocationOffset - document.getLineOffset(startLine);
+        int adjustedInvocationOffset = invocationOffset;
+        if (viewer instanceof ITextViewerExtension5) {
+            ITextViewerExtension5 extension = (ITextViewerExtension5) viewer;
+            adjustedInvocationOffset = extension.widgetOffset2ModelOffset(invocationOffset);
+        }
+        var startLine = document.getLineOfOffset(adjustedInvocationOffset);
+        var lineOffset = adjustedInvocationOffset - document.getLineOffset(startLine);
         invocationPosition.setLine(startLine);
         invocationPosition.setCharacter(lineOffset);
         params.setPosition(invocationPosition);


### PR DESCRIPTION
*Issue #, if available:*

*Explanation:* 
- Some editors (like the ones used by eclipse in default) would "fold" lines to hide verbosity such as import statement, license, or comment blocks. 
- APIs such as `StyledText::getCaretOffset` respects the document's visual state and accounts for these folded lines. This is important because the rendering of suggestion needs to make sense with how the document is presented in the editor. 
- However, when the same API was used to construct parameters to query the lsp server with,  problem arises because the lsp server always sees the expanded version of the document, rendering the offset used inaccurate. As a result, the suggestions returned when there are lines folded are inappropriate with respect to the caret position (they are actually a suggestion made for a caret position _above_ where it is in the editor). 
- Furthermore, the API used to insert suggestion, unlike `StyledText::getCaretOffset`, operates with no understanding folding, therefore resulting in an insertion of suggestion in an incorrect position. 

*Description of changes:*
- Adds check to see if the `ITextViewer` is an `ITextViewerExtension5` (only these will fold lines).
- If so, we convert the "relative" offset to "absolute" before constructing a query param with it.
- The same check is also performed during suggestion insertion. 

## Test
Some explanation for the test: 
- With all lines expanded (i.e. no folding), a suggestion is triggered
- Folding one more than line
- Once again trigger for suggestion at the same place in the document
- Observe that the suggestions are identical to what was obtained in the first trigger
- Accept suggestions with the aforementioned lines still folded
- Observe that the insertion is done at the expected location
![ezgif-1-4348094f56](https://github.com/user-attachments/assets/1daae86e-8a6f-4622-9151-e55825f454c9)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
