### PR TITLE
Show telemetry notification on first start up

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/LspStartupActivity.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/LspStartupActivity.java
@@ -89,6 +89,7 @@ public class LspStartupActivity implements IStartup {
         workbench.getDisplay().asyncExec(new Runnable() {
             public void run() {
                 try {
+                    showTelemetryNotification();
                     IWorkbenchWindow window = workbench.getActiveWorkbenchWindow();
                     if (window != null) {
                         IWorkbenchPage page = window.getActivePage();
@@ -141,6 +142,13 @@ public class LspStartupActivity implements IStartup {
             }
         };
         Activator.getPluginStore().addChangeListener(prefChangeListener);
+    }
+
+    private void showTelemetryNotification() {
+        AbstractNotificationPopup notification = new ToolkitNotification(Display.getCurrent(),
+                Constants.TELEMETRY_NOTIFICATION_TITLE,
+                Constants.TELEMETRY_NOTIFICATION_BODY);
+        notification.open();
     }
 
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
@@ -27,4 +27,7 @@ public final class Constants {
     public static final String IDC_PROFILE_NAME = "eclipse-q-profile";
     public static final String IDC_SESSION_NAME = "eclipse-q-session";
     public static final String IDC_PROFILE_KIND = "SsoTokenProfile";
+    public static final String TELEMETRY_NOTIFICATION_TITLE = "AWS IDE plugins telemetry";
+    public static final String TELEMETRY_NOTIFICATION_BODY = "Usage metrics are collected by default. This can be changed in the \"Amazon Q\" section"
+            + " of the IDE preferences.";
 }


### PR DESCRIPTION
*Description of changes:*
Display a notification on first run letting users know that the plugin collects telemetry and the behavior is on by default.

<img width="416" alt="Screenshot 2024-11-04 at 10 45 03 AM" src="https://github.com/user-attachments/assets/577bd170-4d84-45ee-bb43-197b4cb2286f">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
