### PR TITLE
Sign out action always navigates to Login

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/SignoutAction.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/SignoutAction.java
@@ -25,7 +25,6 @@ public final class SignoutAction extends Action implements AuthStatusChangedList
                 if (loginDetails.getIsLoggedIn()) {
                     Activator.getLoginService().logout().get();
                 }
-                return;
             } catch (Exception e) {
                 PluginUtils.showErrorDialog("Amazon Q", "An error occurred while attempting to sign out of Amazon Q. Please try again.");
                 Activator.getLogger().error("Failed to sign out", e);


### PR DESCRIPTION
*Description of changes:*
- Move sign out logic outside of conditional to always execute logic. This will ensure we end up at the desired state at the end of the action.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
