### PR TITLE
Block LSP calls until ExtendedInitializeResult is recieved

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServerBuilder.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServerBuilder.java
@@ -24,6 +24,7 @@ import software.aws.toolkits.eclipse.amazonq.telemetry.metadata.PluginClientMeta
 public class AmazonQLspServerBuilder extends Builder<AmazonQLspServer> {
 
     private static final String USER_AGENT_CLIENT_NAME = "AmazonQ-For-Eclipse";
+    private static Launcher<AmazonQLspServer> launcher;
 
     @Override
     public final Launcher<AmazonQLspServer> create() {
@@ -32,8 +33,7 @@ public class AmazonQLspServerBuilder extends Builder<AmazonQLspServer> {
            builder.registerTypeAdapterFactory(new QLspTypeAdapterFactory());
            builder.setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE);
         });
-        Launcher<AmazonQLspServer> launcher = super.create();
-        Activator.getLspProvider().setServer(AmazonQLspServer.class, launcher.getRemoteProxy());
+        launcher = super.create();
         return launcher;
     }
 
@@ -66,6 +66,7 @@ public class AmazonQLspServerBuilder extends Builder<AmazonQLspServer> {
                 AwsExtendedInitializeResult result = (AwsExtendedInitializeResult) ((ResponseMessage) message).getResult();
                 var awsServerCapabiltiesProvider = AwsServerCapabiltiesProvider.getInstance();
                 awsServerCapabiltiesProvider.setAwsServerCapabilties(result.getAwsServerCapabilities());
+                Activator.getLspProvider().setServer(AmazonQLspServer.class, launcher.getRemoteProxy());
             }
             consumer.consume(message);
         });

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/LspProviderImpl.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/LspProviderImpl.java
@@ -15,7 +15,7 @@ import software.aws.toolkits.eclipse.amazonq.lsp.AmazonQLspServer;
 public final class LspProviderImpl implements LspProvider {
     private static final LspProviderImpl INSTANCE = new LspProviderImpl();
 
-    private static final long TIMEOUT_SECONDS = 10L;
+    private static final long TIMEOUT_SECONDS = 60L;
 
     private final Map<Class<? extends LanguageServer>, CompletableFuture<LanguageServer>> futures;
     private final Map<Class<? extends LanguageServer>, LanguageServer> servers;


### PR DESCRIPTION
*Description of changes:*
It appears that components of the Flare server are not fully initialized when the connection is first established, meaning that there is a race condition for initial calls, e.g. to retrieve auth status. This change blocks usage of the LSP until the initialize result has been received.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
