### PR TITLE
Remove 2x showView on login and logout

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/LoginViewActionHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/LoginViewActionHandler.java
@@ -6,7 +6,6 @@ package software.aws.toolkits.eclipse.amazonq.views;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import org.eclipse.swt.browser.Browser;
-import org.eclipse.swt.widgets.Display;
 import software.amazon.awssdk.regions.servicemetadata.OidcServiceMetadata;
 import software.amazon.awssdk.utils.StringUtils;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.LoginIdcParams;
@@ -52,9 +51,6 @@ public class LoginViewActionHandler implements ViewActionHandler {
                                     new LoginParams().setLoginIdcParams(loginIdcParams)).get();
                         }
                         isLoginTaskRunning = false;
-                        Display.getDefault().asyncExec(() -> {
-                            AmazonQView.showView(AmazonQChatWebview.ID);
-                        });
                     } catch (Exception e) {
                         isLoginTaskRunning = false;
                         Activator.getLogger().error("Failed to update token", e);

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/SignoutAction.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/SignoutAction.java
@@ -9,8 +9,6 @@ import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
 import software.aws.toolkits.eclipse.amazonq.util.Constants;
 import software.aws.toolkits.eclipse.amazonq.util.ThreadingUtils;
 import software.aws.toolkits.eclipse.amazonq.util.PluginUtils;
-import software.aws.toolkits.eclipse.amazonq.views.AmazonQView;
-import software.aws.toolkits.eclipse.amazonq.views.ToolkitLoginWebview;
 import software.aws.toolkits.eclipse.amazonq.telemetry.UiTelemetryProvider;
 
 public final class SignoutAction extends Action implements AuthStatusChangedListener {
@@ -36,7 +34,6 @@ public final class SignoutAction extends Action implements AuthStatusChangedList
             Activator.getLogger().info("Signed out of Amazon q");
             Activator.getPluginStore().remove(Constants.CUSTOMIZATION_STORAGE_INTERNAL_KEY);
             ThreadingUtils.executeAsyncTask(() -> CustomizationUtil.triggerChangeConfigurationNotification());
-            AmazonQView.showView(ToolkitLoginWebview.ID);
         });
     }
 


### PR DESCRIPTION
*Description of changes:*
- View displaying is triggered by the AuthStatusListeners therefore we no longer to explicitly show the view when changing auth state

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
