### PR TITLE
Fix for UI bug when clicking Q Icon and extra telemetry noise

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/handlers/QOpenLoginViewHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/handlers/QOpenLoginViewHandler.java
@@ -5,13 +5,18 @@ package software.aws.toolkits.eclipse.amazonq.handlers;
 
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
+import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
 
 import software.aws.toolkits.eclipse.amazonq.views.ViewVisibilityManager;
 
 public class QOpenLoginViewHandler extends AbstractHandler {
     @Override
     public final Object execute(final ExecutionEvent event) {
-        ViewVisibilityManager.showLoginView();
+        if (Activator.getLoginService().getAuthState().isLoggedIn()) {
+            ViewVisibilityManager.showChatView();
+        } else {
+            ViewVisibilityManager.showLoginView();
+        }
         return null;
     }
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/ViewVisibilityManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/ViewVisibilityManager.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IViewReference;
 import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
@@ -73,6 +74,10 @@ public final class ViewVisibilityManager {
             if (window != null) {
                 IWorkbenchPage page = window.getActivePage();
                 if (page != null) {
+                    if (viewIsAlreadyOpen(page, viewId)) {
+                        Activator.getLogger().info(viewId + " is already the active view.");
+                        return;
+                    }
                     // Hide other Views
                     IViewReference[] viewReferences = page.getViewReferences();
                     for (IViewReference viewRef : viewReferences) {
@@ -106,6 +111,10 @@ public final class ViewVisibilityManager {
         if (window != null) {
             IWorkbenchPage page = window.getActivePage();
             if (page != null) {
+                if (viewIsAlreadyOpen(page, viewId)) {
+                    Activator.getLogger().info(viewId + " is already the active view.");
+                    return;
+                }
                 try {
                     page.showView(viewId);
                     Activator.getLogger().info("Showing view " + viewId);
@@ -114,5 +123,15 @@ public final class ViewVisibilityManager {
                 }
             }
         }
+    }
+    private static boolean viewIsAlreadyOpen(final IWorkbenchPage page, final String viewId) {
+        IWorkbenchPartReference activeRef = page.getActivePartReference();
+        if (activeRef instanceof IViewReference) {
+            IViewReference activeViewId = (IViewReference) activeRef;
+            if (activeViewId.getId().equals(viewId)) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
This PR fixes the momentary double view showing when clicking the Q Icon, as well as fixing added telemetry noise when rendering views.
* Added auth status check to Q icon click action to ensure showView is called on correct page
* added debounce to show view method to prevent code firing unnecessarily when view is already open

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
