### PR TITLE
Fix bug where a border would appear around some chat view icons

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
@@ -159,7 +159,7 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
                     <meta
                         http-equiv="Content-Security-Policy"
                         content="default-src 'none'; script-src %s 'unsafe-inline'; style-src %s 'unsafe-inline';
-                        img-src 'self' data:; object-src 'none'; base-uri 'none';"
+                        img-src 'self' data:; object-src 'none'; base-uri 'self';i 'none';"
                     >
                     <title>Chat UI</title>
                     %s
@@ -183,6 +183,17 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
                         overflow: hidden;
                         margin: 0;
                         padding: 0;
+                    }
+                    .mynah-ui-icon-plus,
+                    .mynah-ui-icon-cancel {
+                        -webkit-mask-size: 155% !important;
+                        mask-size: 155% !important;
+                        mask-position: center;
+                    }
+                    .mynah-ui-icon-tabs {
+                        -webkit-mask-size: 102% !important;
+                        mask-size: 102% !important;
+                        mask-position: center;
                     }
                     textarea:placeholder-shown {
                         line-height: 1.5rem;


### PR DESCRIPTION
*Description of changes:*
A border appears around the close tab and open tab buttons sometimes. This is because the mask (icon) does not fill the UI component fully and the background bleeds through around the edges. This temporary fix makes the masks bigger so the background does not bleed through. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
