### PR TITLE
Fix scale for chat UI buttons

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
@@ -189,6 +189,7 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
                         -webkit-mask-size: 155% !important;
                         mask-size: 155% !important;
                         mask-position: center;
+                        scale: 60%;
                     }
                     .mynah-ui-icon-tabs {
                         -webkit-mask-size: 102% !important;


### PR DESCRIPTION
*Description of changes:*
#201 fixed the border issue for these icons but the scale of the icons is still a bit large. This proportions them in line with the rest of the UI.

<img width="146" alt="image" src="https://github.com/user-attachments/assets/75089d01-1b57-4b40-9056-40880fb43b45">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
