### PR TITLE
Ensure all views show up relative to login view

### DIFF
--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -126,19 +126,19 @@
             </view>
             <view
                 id="software.aws.toolkits.eclipse.amazonq.views.ReauthenticateView"
-                relative="software.aws.toolkits.eclipse.amazonq.views.AmazonQChatWebview"
+                relative="software.aws.toolkits.eclipse.amazonq.views.ToolkitLoginWebview"
                 relationship="stack"
                 visible="false">
             </view>
             <view
                 id="software.aws.toolkits.eclipse.amazonq.views.DependencyMissingView"
-                relative="software.aws.toolkits.eclipse.amazonq.views.AmazonQChatWebview"
+                relative="software.aws.toolkits.eclipse.amazonq.views.ToolkitLoginWebview"
                 relationship="stack"
                 visible="false">
             </view>
              <view
                 id="software.aws.toolkits.eclipse.amazonq.views.ChatAssetMissingView"
-                relative="software.aws.toolkits.eclipse.amazonq.views.AmazonQChatWebview"
+                relative="software.aws.toolkits.eclipse.amazonq.views.ToolkitLoginWebview"
                 relationship="stack"
                 visible="false">
             </view>


### PR DESCRIPTION
*Description of changes:*
All views should render relative to login view. This ensures that if chat view is not loaded, the other views are anchored off of the toolkit login view

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
