### PR TITLE
Initial telemetry emitter pattern

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/plugin/Activator.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/plugin/Activator.java
@@ -6,17 +6,20 @@ package software.aws.toolkits.eclipse.amazonq.plugin;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
+import software.aws.toolkits.eclipse.amazonq.chat.ChatStateManager;
 import software.aws.toolkits.eclipse.amazonq.configuration.DefaultPluginStore;
 import software.aws.toolkits.eclipse.amazonq.configuration.PluginStore;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.DefaultLoginService;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.LoginService;
 import software.aws.toolkits.eclipse.amazonq.providers.LspProvider;
 import software.aws.toolkits.eclipse.amazonq.providers.LspProviderImpl;
+import software.aws.toolkits.eclipse.amazonq.telemetry.TelemetryEmitterManager;
+import software.aws.toolkits.eclipse.amazonq.telemetry.api.Emittable;
+import software.aws.toolkits.eclipse.amazonq.telemetry.models.TelemetryEventRecord;
 import software.aws.toolkits.eclipse.amazonq.telemetry.service.DefaultTelemetryService;
 import software.aws.toolkits.eclipse.amazonq.telemetry.service.TelemetryService;
-import software.aws.toolkits.eclipse.amazonq.util.PluginLogger;
-import software.aws.toolkits.eclipse.amazonq.chat.ChatStateManager;
 import software.aws.toolkits.eclipse.amazonq.util.LoggingService;
+import software.aws.toolkits.eclipse.amazonq.util.PluginLogger;
 
 public class Activator extends AbstractUIPlugin {
 
@@ -27,6 +30,7 @@ public class Activator extends AbstractUIPlugin {
     private static LspProvider lspProvider;
     private static LoginService loginService;
     private static PluginStore pluginStore;
+    private static TelemetryEmitterManager telemetryEmitterManager;
 
     public Activator() {
         super();
@@ -35,6 +39,7 @@ public class Activator extends AbstractUIPlugin {
         telemetryService = DefaultTelemetryService.builder().build();
         lspProvider = LspProviderImpl.getInstance();
         pluginStore = DefaultPluginStore.getInstance();
+        telemetryEmitterManager = new TelemetryEmitterManager();
         loginService = DefaultLoginService.builder()
                 .withLspProvider(lspProvider)
                 .withPluginStore(pluginStore)
@@ -68,6 +73,9 @@ public class Activator extends AbstractUIPlugin {
     }
     public static PluginStore getPluginStore() {
         return pluginStore;
+    }
+    public static <T extends TelemetryEventRecord> Emittable<T> getTelemetryEmitterFor(final Class<T> type) {
+        return telemetryEmitterManager.getEmitterFor(type);
     }
 
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/telemetry/TelemetryEmitterManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/telemetry/TelemetryEmitterManager.java
@@ -1,0 +1,45 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.telemetry;
+
+import java.util.Map;
+import java.util.Objects;
+
+import software.aws.toolkits.eclipse.amazonq.telemetry.api.Emittable;
+import software.aws.toolkits.eclipse.amazonq.telemetry.implementations.UITelemetryEmitter;
+import software.aws.toolkits.eclipse.amazonq.telemetry.models.TelemetryEventRecord;
+import software.aws.toolkits.eclipse.amazonq.telemetry.models.UITelemetryEventRecord;
+
+public final class TelemetryEmitterManager {
+
+    private UITelemetryEmitter uiTelemetryEmitter;
+
+    private Map<Class<?>, Object> emitterMap;
+
+    public TelemetryEmitterManager() {
+        initializeEmitters();
+        initializeMap();
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends TelemetryEventRecord> Emittable<T> getEmitterFor(final Class<T> type) {
+        Objects.requireNonNull(type, "Type cannot be null");
+
+        Emittable<T> emitter = (Emittable<T>) emitterMap.get(type);
+        if (emitter == null) {
+            throw new IllegalArgumentException("No emitter found for type: " + type.getName());
+        }
+        return emitter;
+    }
+
+
+    private void initializeEmitters() {
+        uiTelemetryEmitter = new UITelemetryEmitter();
+    }
+
+    private void initializeMap() {
+        emitterMap = Map.of(UITelemetryEventRecord.class, uiTelemetryEmitter);
+    }
+
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/telemetry/api/Emittable.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/telemetry/api/Emittable.java
@@ -1,0 +1,23 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.telemetry.api;
+
+import software.amazon.awssdk.services.toolkittelemetry.model.MetricDatum;
+import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
+import software.aws.toolkits.eclipse.amazonq.telemetry.models.EmittableEventType;
+import software.aws.toolkits.eclipse.amazonq.telemetry.models.TelemetryEventRecord;
+
+public abstract class Emittable<T extends TelemetryEventRecord> {
+
+    public final void emit(final EmittableEventType type, final T event) {
+        emitDatum(getMetricDatum(type, event));
+    }
+
+    protected final void emitDatum(final MetricDatum metricDatum) {
+        Activator.getTelemetryService().emitMetric(metricDatum);
+    }
+
+    protected abstract MetricDatum getMetricDatum(EmittableEventType type, T event);
+
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/telemetry/implementations/UITelemetryEmitter.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/telemetry/implementations/UITelemetryEmitter.java
@@ -1,0 +1,28 @@
+package software.aws.toolkits.eclipse.amazonq.telemetry.implementations;
+
+import java.time.Instant;
+
+import software.amazon.awssdk.services.toolkittelemetry.model.MetricDatum;
+import software.aws.toolkits.eclipse.amazonq.telemetry.api.Emittable;
+import software.aws.toolkits.eclipse.amazonq.telemetry.models.EmittableEventType;
+import software.aws.toolkits.eclipse.amazonq.telemetry.models.UITelemetryEventRecord;
+import software.aws.toolkits.telemetry.TelemetryDefinitions.Result;
+import software.aws.toolkits.telemetry.UiTelemetry;
+
+public class UITelemetryEmitter extends Emittable<UITelemetryEventRecord> {
+
+    @Override
+    protected final MetricDatum getMetricDatum(final EmittableEventType type, final UITelemetryEventRecord event) {
+        if (type != EmittableEventType.UI_ELEMENT_CLICK_EVENT) {
+            throw new IllegalArgumentException("Invalid event type for UI telemetry");
+        }
+
+        return UiTelemetry.ClickEvent()
+                .elementId(event.elementId())
+                .passive(false)
+                .createTime(Instant.now())
+                .result(Result.SUCCEEDED)
+                .build();
+    }
+
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/telemetry/models/EmittableEventType.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/telemetry/models/EmittableEventType.java
@@ -1,0 +1,5 @@
+package software.aws.toolkits.eclipse.amazonq.telemetry.models;
+
+public enum EmittableEventType {
+    UI_ELEMENT_CLICK_EVENT
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/telemetry/models/TelemetryEventRecord.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/telemetry/models/TelemetryEventRecord.java
@@ -1,0 +1,16 @@
+package software.aws.toolkits.eclipse.amazonq.telemetry.models;
+
+public class TelemetryEventRecord {
+
+    public TelemetryEventRecord() {
+        super();
+    }
+
+    protected abstract static class TelemetryEventBuilder<T extends TelemetryEventRecord, B extends TelemetryEventBuilder<T, B>> {
+
+        protected abstract B self();
+        public abstract T build();
+
+    }
+
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/telemetry/models/UITelemetryEventRecord.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/telemetry/models/UITelemetryEventRecord.java
@@ -1,0 +1,57 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.telemetry.models;
+
+public class UITelemetryEventRecord extends TelemetryEventRecord {
+
+    private final String elementId;
+
+    protected UITelemetryEventRecord(final String elementId) {
+        if (elementId == null || elementId.isEmpty()) {
+            throw new IllegalArgumentException("elementId cannot be null or empty");
+        }
+        this.elementId = elementId;
+    }
+
+    public final String elementId() {
+        return elementId;
+    }
+
+    public static class Builder extends TelemetryEventBuilder<UITelemetryEventRecord, Builder> {
+
+        private String elementId;
+
+        public final Builder withElementId(final String elementId) {
+            this.elementId = elementId;
+            return this;
+        }
+
+        /**
+         * Overrides the default implementation to return this instance, as required by the base class.
+         *
+         * @return this builder
+         */
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+
+        /**
+         * Overrides the build method to return an instance of the TelemetryEvent class.
+         *
+         * @return a new instance of TelemetryEvent
+         */
+        @Override
+        public UITelemetryEventRecord build() {
+            return new UITelemetryEventRecord(elementId);
+        }
+
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/DialogContributionItem.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/DialogContributionItem.java
@@ -11,7 +11,10 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
-import software.aws.toolkits.eclipse.amazonq.telemetry.UiTelemetryProvider;
+
+import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
+import software.aws.toolkits.eclipse.amazonq.telemetry.models.EmittableEventType;
+import software.aws.toolkits.eclipse.amazonq.telemetry.models.UITelemetryEventRecord;
 
 public class DialogContributionItem extends ContributionItem {
     private Dialog dialog;
@@ -41,7 +44,13 @@ public class DialogContributionItem extends ContributionItem {
         menuItem.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(final SelectionEvent e) {
-                UiTelemetryProvider.emitClickEventMetric("amazonq_shareFeedback");
+                UITelemetryEventRecord eventRecord = UITelemetryEventRecord.builder()
+                        .withElementId("amazonq_shareFeedback")
+                        .build();
+
+                Activator.getTelemetryEmitterFor(UITelemetryEventRecord.class)
+                    .emit(EmittableEventType.UI_ELEMENT_CLICK_EVENT, eventRecord);
+
                 dialog.open();
             }
         });


### PR DESCRIPTION
*Description of changes:*
- The telemetry emitting is done through static providers currently. This pattern makes sense because code for emitting metrics is not reused in many places, and also this setup also makes the flow very straight-forward to understand for new users. We also need to objectively write less lines of code, so the implementation is very concise right now.
- The problem is that with static providers, it is very difficult to establish a pattern for development. It also adds a requirement to use static mocks or writing extensions when testing. The parameters for different events can also vary, and using function parameters doesn't make what value is being set explicit. 
- The pattern recommended here allows for a more consistent call when emitting telemetry. It does not use static methods or variables which might make testing simpler. As the parameter list grows, it might make which elements are being referred to more explicit enhancing readability. It enforces that builders must be provided for different record types as well.

The naming conventions can be improved and iterated upon.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
