### PR TITLE
Adds null check for content type

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QEclipseEditorUtils.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QEclipseEditorUtils.java
@@ -330,6 +330,9 @@ public final class QEclipseEditorUtils {
             IContentType contentType = Platform.getContentTypeManager().findContentTypeFor(file.getName());
             contentTypeName = contentType.getName();
         }
+        if (contentTypeName == null) {
+            return Optional.empty();
+        }
         switch (contentTypeName) {
         // TODO: Add more supported file types here:
         case "Java Source File":


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Adds null check for content type to return default bracket settings 

*Note*:
We'll need to find out why as I do plan to do a slight refactor based on the file type (eclipse behaves differently on different file types) and this function would be the focal point

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
