### PR TITLE
Apply consistent retry & timeout behavior

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/fetcher/RemoteLspFetcher.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/fetcher/RemoteLspFetcher.java
@@ -38,7 +38,7 @@ import software.aws.toolkits.eclipse.amazonq.util.PluginPlatform;
 
 public final class RemoteLspFetcher implements LspFetcher {
 
-    private static final int TIMEOUT_SECONDS = 10;
+    private static final int TIMEOUT_SECONDS = 30;
 
     private final Manifest manifest;
     private final VersionRange versionRange;

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/fetcher/VersionManifestFetcher.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/fetcher/VersionManifestFetcher.java
@@ -25,7 +25,7 @@ import software.aws.toolkits.eclipse.amazonq.util.PluginUtils;
 
 public final class VersionManifestFetcher {
 
-    private static final int TIMEOUT_SECONDS = 10;
+    private static final int TIMEOUT_SECONDS = 30;
     private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
 
     private final String manifestUrl;

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/HttpClientFactory.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/HttpClientFactory.java
@@ -8,6 +8,7 @@ import java.net.MalformedURLException;
 import java.net.ProxySelector;
 import java.net.URL;
 import java.net.http.HttpClient;
+import java.time.Duration;
 
 import software.amazon.awssdk.utils.StringUtils;
 
@@ -33,7 +34,8 @@ public final class HttpClientFactory {
                     if (customSslContext != null) {
                         builder.sslContext(ProxyUtil.getCustomSslContext());
                     }
-                    instance = builder.build();
+                    instance = builder.connectTimeout(Duration.ofSeconds(10))
+                            .build();
                 }
             }
         }


### PR DESCRIPTION
*Description of changes:*
* 30 second read timeout on requests from our internal HTTP client (matches the AWS SDK default).
* Standard retry policy on the AWS SDK used for our Telemetry service
* 10 second connection timeout on our internal HTTP client. This is higher than the AWS SDK default of 2 seconds, but I wanted to add a bit of buffer given how critical the calls here are to the operation of the plugin (LSP fetching).

I also added basic error handling to the telemetry service, so that failures do not impact callers. In the future, batching and retry will be added to the telemetry client so we don't drop data, but for now this at least ensures that failures will not impact the customer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
