### PR TITLE
Force clients to use TLS v1.2

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/ProxyUtil.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/ProxyUtil.java
@@ -80,7 +80,7 @@ public final class ProxyUtil {
                 TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
                 tmf.init(keyStore);
 
-                SSLContext sslContext = SSLContext.getInstance("TLS");
+                SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
                 sslContext.init(null, tmf.getTrustManagers(), null);
                 Activator.getLogger().info("Picked up custom CA cert.");
 


### PR DESCRIPTION
*Description of changes:*
Forces our internal client and the AWS SDK client for Telemetry to use TLS v1.2 to communicate over SSL.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
