### PR TITLE
Consistently update auth status in failure cases

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/auth/DefaultLoginService.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/auth/DefaultLoginService.java
@@ -72,6 +72,7 @@ public final class DefaultLoginService implements LoginService {
         return processLogin(loginType, loginParams, true)
                 .exceptionally(throwable -> {
                     Activator.getLogger().error("Failed to log in", throwable);
+                    logout();
                     return null;
                 });
     }
@@ -138,6 +139,7 @@ public final class DefaultLoginService implements LoginService {
         return processLogin(authState.loginType(), authState.loginParams(), loginOnInvalidToken)
                 .exceptionally(throwable -> {
                     Activator.getLogger().error("Failed to re-authenticate", throwable);
+                    logout();
                     return null;
                 });
     }


### PR DESCRIPTION
*Description of changes:*
This specifically addresses a bug where a failed reauth fails to update the login state to logged out, therefore leading to inconsistent behavior across the extension. This should also clean up any partial login state on a failed login.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
