### PR TITLE
Moves session state transition out of display thread

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QInlineInputListener.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QInlineInputListener.java
@@ -446,9 +446,9 @@ public final class QInlineInputListener implements IDocumentListener, VerifyKeyL
 
         boolean isOutOfBounds = distanceTraversed + input.length() >= currentSuggestion.length() || distanceTraversed < 0;
         if (isOutOfBounds || !isInputAMatch(currentSuggestion, distanceTraversed, input)) {
+            session.transitionToDecisionMade();
             Display.getCurrent().asyncExec(() -> {
                 if (session.isActive()) {
-                    session.transitionToDecisionMade();
                     session.end();
                 }
             });


### PR DESCRIPTION
*Issue #, if available:*
Currently if you perform the following, an unhandled exception would take place in the rendering logic:
- Preview a suggestion
- Hit enter 

This is because the session state change happens in the display thread and not the thread that terminates the session. This introduces a delay between rendering logic starts a fresh loop and when the state is actually changed. 

*Description of changes:*
- Updates session state prior to scheduling clean up routine in the display thread. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
