### PR TITLE
Telemetry emission for init stage and full process

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServerBuilder.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServerBuilder.java
@@ -66,7 +66,7 @@ public class AmazonQLspServerBuilder extends Builder<AmazonQLspServer> {
                 AwsExtendedInitializeResult result = (AwsExtendedInitializeResult) ((ResponseMessage) message).getResult();
                 var awsServerCapabiltiesProvider = AwsServerCapabiltiesProvider.getInstance();
                 awsServerCapabiltiesProvider.setAwsServerCapabilties(result.getAwsServerCapabilities());
-                Activator.getLspProvider().setServer(AmazonQLspServer.class, launcher.getRemoteProxy());
+                Activator.getLspProvider().setAmazonQServer(launcher.getRemoteProxy());
             }
             consumer.consume(message);
         });

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/fetcher/RemoteLspFetcher.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/fetcher/RemoteLspFetcher.java
@@ -67,6 +67,9 @@ public final class RemoteLspFetcher implements LspFetcher {
         args.setLocation(location);
         args.setLanguageServerVersion(serverVersion);
         args.setReason(reason);
+        if (manifest != null) {
+            args.setManifestSchemaVersion(manifest.manifestSchemaVersion());
+        }
         LanguageServerTelemetryProvider.emitSetupGetServer(result, args);
     }
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/LspProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/LspProvider.java
@@ -9,6 +9,7 @@ import software.aws.toolkits.eclipse.amazonq.lsp.AmazonQLspServer;
 
 public interface LspProvider {
     <T extends LanguageServer> void setServer(Class<T> lspType, T server);
+    void setAmazonQServer(LanguageServer server);
     CompletableFuture<AmazonQLspServer> getAmazonQServer();
 }
 


### PR DESCRIPTION
*Description of changes:*
This PR includes the addition of telemetry metrics for the initialization of the amazon Q LSP server, as well as metrics for the full process of fetching and starting the LSP. Some additional QoL changes featured in this PR include:
* abstracting logic for setting AmazonQ server into its own method
* added logic to include error message in getManifest metric on failure case
* included manifest & server location data in validate LSP step

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.