### PR TITLE
Add tests for chat model components

### DIFF
--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/ChatItemActionTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/ChatItemActionTest.java
@@ -1,0 +1,64 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ChatItemActionTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final String pillText = "Click me";
+    private final String prompt = "Test prompt";
+    private final Boolean disabled = false;
+    private final String description = "Test description";
+    private final String type = "button";
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        ChatItemAction action = new ChatItemAction(pillText, prompt, disabled, description, type);
+
+        assertEquals(pillText, action.pillText());
+        assertEquals(prompt, action.prompt());
+        assertEquals(disabled, action.disabled());
+        assertEquals(description, action.description());
+        assertEquals(type, action.type());
+    }
+
+    @Test
+    void testJsonSerialization() throws Exception {
+        ChatItemAction action = new ChatItemAction(pillText, prompt, disabled, description, type);
+
+        String serializedObject = objectMapper.writeValueAsString(action);
+
+        assertEquals(serializedObject,
+                "{\"pillText\":\"Click me\",\"prompt\":\"Test prompt\",\"disabled\":false,\"description\":\"Test description\",\"type\":\"button\"}");
+    }
+
+    @Test
+    void testDeserialization() throws Exception {
+        String json = "{\"pillText\":\"Click me\",\"prompt\":\"Test prompt\",\"disabled\":false,\"description\":\"Test description\",\"type\":\"button\"}";
+
+        ChatItemAction chatItemAction = assertDoesNotThrow(() -> objectMapper.readValue(json, ChatItemAction.class));
+
+        assertEquals(pillText, chatItemAction.pillText());
+        assertEquals(prompt, chatItemAction.prompt());
+        assertEquals(disabled, chatItemAction.disabled());
+        assertEquals(type, chatItemAction.type());
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, ChatRequestParams.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/ChatPromptTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/ChatPromptTest.java
@@ -1,0 +1,58 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ChatPromptTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String prompt = "Test prompt";
+    private final String escapedPrompt = "Test escaped prompt";
+    private final String command = "Test command";
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        ChatPrompt chatPrompt = new ChatPrompt(prompt, escapedPrompt, command);
+
+        assertEquals(prompt, chatPrompt.prompt());
+        assertEquals(escapedPrompt, chatPrompt.escapedPrompt());
+        assertEquals(command, chatPrompt.command());
+    }
+
+    @Test
+    void testJsonSerialization() throws Exception {
+        ChatPrompt chatPrompt = new ChatPrompt(prompt, escapedPrompt, command);
+        String serializedObject = objectMapper.writeValueAsString(chatPrompt);
+
+        assertEquals(serializedObject,
+                "{\"prompt\":\"Test prompt\",\"escapedPrompt\":\"Test escaped prompt\",\"command\":\"Test command\"}");
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"prompt\":\"Test prompt\",\"escapedPrompt\":\"Test escaped prompt\",\"command\":\"Test command\"}";
+
+        ChatPrompt deserializedPrompt = objectMapper.readValue(json, ChatPrompt.class);
+
+        assertEquals("Test prompt", deserializedPrompt.prompt());
+        assertEquals("Test escaped prompt", deserializedPrompt.escapedPrompt());
+        assertEquals("Test command", deserializedPrompt.command());
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, ChatPrompt.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/ChatRequestParamsTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/ChatRequestParamsTest.java
@@ -1,0 +1,105 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ChatRequestParamsTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String tabId = "tabId";
+
+    private final String prompt = "prompt";
+    private final String escapedPrompt = "escapedPrompt";
+    private final String command = "command";
+    private final ChatPrompt chatPrompt = new ChatPrompt(prompt, escapedPrompt, command);
+
+    private final String partialResultToken = "partialResultToken";
+
+    private final String textDocumentUri = "test/file.txt";
+    private final TextDocumentIdentifier textDocumentIdentifier = new TextDocumentIdentifier(textDocumentUri);
+
+    private final Position startPosition = new Position(0, 0);
+    private final Position endPosition = new Position(100, 100);
+    private final Range range = new Range(startPosition, endPosition);
+    private final CursorState cursorState = new CursorState(range);
+    private final List<CursorState> cursorStateList = List.of(cursorState);
+
+    @Test
+    void testSettersGetters() {
+        ChatRequestParams chatRequestParams = new ChatRequestParams(tabId, chatPrompt,
+                new TextDocumentIdentifier("newDocumentUri"), new CursorState(new Range(startPosition, endPosition)));
+
+        assertEquals(tabId, chatRequestParams.getTabId());
+        assertEquals(chatPrompt, chatRequestParams.getPrompt());
+//        assertNotNull(chatRequestParams.getTextDocument());
+//        assertNotNull(chatRequestParams.getCursorState());
+
+        chatRequestParams.setPartialResultToken(partialResultToken);
+        chatRequestParams.setCursorState(cursorStateList);
+        chatRequestParams.setTextDocument(textDocumentIdentifier);
+
+        assertEquals(partialResultToken, chatRequestParams.getPartialResultToken());
+        assertEquals(cursorStateList, chatRequestParams.getCursorState());
+        assertEquals(textDocumentIdentifier, chatRequestParams.getTextDocument());
+    }
+
+    @Test
+    void testDeserialization() {
+        String json = """
+                {
+                    "tabId": "tabId",
+                    "prompt": {
+                        "prompt": "prompt",
+                        "escapedPrompt": "escapedPrompt",
+                        "command": "command"
+                    },
+                    "textDocument": {
+                        "uri": "test/file.txt"
+                    },
+                    "cursorState": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 100,
+                                "character": 100
+                            }
+                        }
+                    }
+                }""";
+
+        ChatRequestParams params = assertDoesNotThrow(() -> objectMapper.readValue(json, ChatRequestParams.class));
+
+        assertEquals(tabId, params.getTabId());
+        assertNotNull(params.getPrompt());
+//        assertEquals(textDocumentUri, params.getTextDocument().getUri());
+//        assertEquals(1, params.getCursorState().size());
+//        assertNotNull(params.getCursorState().get(0));
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, ChatRequestParams.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/ChatResultTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/ChatResultTest.java
@@ -1,0 +1,112 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ChatResultTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String body = "body";
+    private final String messageId = "messageId";
+    private final boolean canBeVoted = true;
+
+    private final SourceLink sourceLink = new SourceLink("title", "url", "body");
+    private final SourceLink[] sourceLinkArray = new SourceLink[] {sourceLink};
+    private final RelatedContent relatedContent = new RelatedContent("title", sourceLinkArray);
+
+    private final String pillText = "Click me";
+    private final String prompt = "Test prompt";
+    private final Boolean disabled = false;
+    private final String description = "Test description";
+    private final String type = "button";
+    private final ChatItemAction chatItemAction = new ChatItemAction(pillText, prompt, disabled, description, type);
+
+    private final String text = "text";
+    private final ChatItemAction[] options = new ChatItemAction[] {chatItemAction};
+
+    private final FollowUp followUp = new FollowUp(text, options);
+
+    private final String licenseName = "licenseName";
+    private final String repository = "repository";
+    private final String url = "url";
+
+    private final Integer startLine = 1;
+    private final Integer endLine = 2;
+    private final RecommendationContentSpan recommendationSpan = new RecommendationContentSpan(startLine, endLine);
+
+    private final String information = "information";
+    private final ReferenceTrackerInformation referenceTrackerInformation = new ReferenceTrackerInformation(licenseName,
+            repository, url, recommendationSpan, information);
+
+    private final ReferenceTrackerInformation[] referenceTrackerInformationList = new ReferenceTrackerInformation[] {
+            referenceTrackerInformation};
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        ChatResult chatResult = new ChatResult(body, messageId, canBeVoted, relatedContent, followUp,
+                referenceTrackerInformationList);
+
+        assertEquals(body, chatResult.body());
+        assertEquals(messageId, chatResult.messageId());
+        assertEquals(canBeVoted, chatResult.canBeVoted());
+        assertEquals(relatedContent, chatResult.relatedContent());
+        assertEquals(followUp, chatResult.followUp());
+        assertEquals(referenceTrackerInformationList, chatResult.codeReference());
+    }
+
+    @Test
+    void testJsonSerialization() throws Exception {
+        ChatResult chatResult = new ChatResult(body, messageId, canBeVoted, relatedContent, followUp,
+                referenceTrackerInformationList);
+
+        String serializedObject = objectMapper.writeValueAsString(chatResult);
+
+        assertEquals(serializedObject, "{\"body\":\"body\",\"messageId\":\"messageId\",\"canBeVoted\":true,"
+                + "\"relatedContent\":{\"title\":\"title\",\"content\":[{\"title\":\"title\",\"url\":\"url\",\"body\":\"body\"}]}"
+                + ",\"followUp\":{\"text\":\"text\",\"options\":[{\"pillText\":\"Click me\",\"prompt\":\"Test prompt\",\"disabled\":false,"
+                + "\"description\":\"Test description\",\"type\":\"button\"}]},\"codeReference\":[{\"licenseName\":\"licenseName\",\"repository\""
+                + ":\"repository\",\"url\":\"url\",\"recommendationContentSpan\":{\"start\":1,\"end\":2},\"information\":\"information\"}]}");
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"body\":\"body\",\"messageId\":\"messageId\",\"canBeVoted\":true,"
+                + "\"relatedContent\":{\"title\":\"title\",\"content\":[{\"title\":\"title\",\"url\":\"url\",\"body\":\"body\"}]}"
+                + ",\"followUp\":{\"text\":\"text\",\"options\":[{\"pillText\":\"Click me\",\"prompt\":\"Test prompt\",\"disabled\":false,"
+                + "\"description\":\"Test description\",\"type\":\"button\"}]},\"codeReference\":[{\"licenseName\":\"licenseName\",\"repository\""
+                + ":\"repository\",\"url\":\"url\",\"recommendationContentSpan\":{\"start\":1,\"end\":2},\"information\":\"information\"}]}";
+
+        ChatResult deserializedResult = objectMapper.readValue(json, ChatResult.class);
+
+        assertEquals(body, deserializedResult.body());
+        assertEquals(messageId, deserializedResult.messageId());
+        assertEquals(canBeVoted, deserializedResult.canBeVoted());
+        assertEquals(relatedContent.title(), deserializedResult.relatedContent().title());
+
+        assertEquals(1, deserializedResult.relatedContent().content().length);
+        assertNotNull(deserializedResult.relatedContent().content()[0]);
+
+        assertEquals(1, deserializedResult.followUp().options().length);
+        assertNotNull(deserializedResult.followUp().options()[0]);
+
+        assertEquals(1, deserializedResult.codeReference().length);
+        assertNotNull(deserializedResult.codeReference()[0]);
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, ChatResult.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/ChatUIInboundCommandNameTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/ChatUIInboundCommandNameTest.java
@@ -1,0 +1,35 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class ChatUIInboundCommandNameTest {
+
+    @Test
+    void testGetValue() {
+        assertEquals("aws/chat/sendChatPrompt", ChatUIInboundCommandName.ChatPrompt.getValue());
+        assertEquals("sendToPrompt", ChatUIInboundCommandName.SendToPrompt.getValue());
+        assertEquals("errorMessage", ChatUIInboundCommandName.ErrorMessage.getValue());
+        assertEquals("insertToCursorPosition", ChatUIInboundCommandName.InsertToCursorPosition.getValue());
+        assertEquals("authFollowUpClicked", ChatUIInboundCommandName.AuthFollowUpClicked.getValue());
+        assertEquals("genericCommand", ChatUIInboundCommandName.GenericCommand.getValue());
+    }
+
+    @Test
+    void testToString() {
+        for (ChatUIInboundCommandName command : ChatUIInboundCommandName.values()) {
+            assertEquals(command.getValue(), command.toString());
+        }
+    }
+
+    @Test
+    void testInvalidEnum() {
+        assertThrows(IllegalArgumentException.class, () -> ChatUIInboundCommandName.valueOf("NonExistentCommand"));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/ChatUIInboundCommandTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/ChatUIInboundCommandTest.java
@@ -1,0 +1,143 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ChatUIInboundCommandTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String command = "command";
+    private final String tabId = "tabId";
+    private final Object params = new Object();
+    private final Boolean isPartialResult = true;
+
+    private final String body = "body";
+    private final String messageId = "messageId";
+    private final boolean canBeVoted = true;
+
+    private final SourceLink sourceLink = new SourceLink("title", "url", "body");
+    private final SourceLink[] sourceLinkArray = new SourceLink[] {sourceLink};
+    private final RelatedContent relatedContent = new RelatedContent("title", sourceLinkArray);
+
+    private final String pillText = "Click me";
+    private final String prompt = "Test prompt";
+    private final Boolean disabled = false;
+    private final String description = "Test description";
+    private final String type = "button";
+    private final ChatItemAction chatItemAction = new ChatItemAction(pillText, prompt, disabled, description, type);
+
+    private final String text = "text";
+    private final ChatItemAction[] options = new ChatItemAction[] {chatItemAction};
+
+    private final FollowUp followUp = new FollowUp(text, options);
+
+    private final String licenseName = "licenseName";
+    private final String repository = "repository";
+    private final String url = "url";
+
+    private final Integer startLine = 1;
+    private final Integer endLine = 2;
+    private final RecommendationContentSpan recommendationSpan = new RecommendationContentSpan(startLine, endLine);
+
+    private final String information = "information";
+    private final ReferenceTrackerInformation referenceTrackerInformation = new ReferenceTrackerInformation(licenseName,
+            repository, url, recommendationSpan, information);
+
+    private final ReferenceTrackerInformation[] referenceTrackerInformationList = new ReferenceTrackerInformation[] {
+            referenceTrackerInformation};
+
+    private final String selection = "selection";
+    private final String triggerType = "triggerType";
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        ChatUIInboundCommand chatUiInboundCommand = new ChatUIInboundCommand(command, tabId, params, isPartialResult);
+
+        assertEquals(command, chatUiInboundCommand.command());
+        assertEquals(tabId, chatUiInboundCommand.tabId());
+        assertEquals(params, chatUiInboundCommand.params());
+        assertEquals(isPartialResult, chatUiInboundCommand.isPartialResult());
+    }
+
+    @Test
+    void testJsonSerialization() throws Exception {
+        ChatResult chatResult = new ChatResult(body, messageId, canBeVoted, relatedContent, followUp,
+                referenceTrackerInformationList);
+        ChatUIInboundCommand chatUiInboundCommand = new ChatUIInboundCommand(command, tabId, chatResult,
+                isPartialResult);
+
+        String serializedObject = objectMapper.writeValueAsString(chatUiInboundCommand);
+
+        assertEquals(
+                "{\"command\":\"command\",\"tabId\":\"tabId\",\"params\":{\"body\":\"body\",\"messageId\":\"messageId\","
+                        + "\"canBeVoted\":true,\"relatedContent\":{\"title\":\"title\",\"content\":[{\"title\":\"title\",\"url\":"
+                        + "\"url\",\"body\":\"body\"}]},\"followUp\":{\"text\":\"text\",\"options\":[{\"pillText\":\"Click me\",\""
+                        + "prompt\":\"Test prompt\",\"disabled\":false,\"description\":\"Test description\",\"type\":\"button\"}]},"
+                        + "\"codeReference\":[{\"licenseName\":\"licenseName\",\"repository\":\"repository\",\"url\":\"url\","
+                        + "\"recommendationContentSpan\":{\"start\":1,\"end\":2},\"information\":\"information\"}]},\"isPartialResult\":true}",
+                serializedObject);
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"command\":\"command\",\"tabId\":\"tabId\",\"params\":{\"body\":\"body\",\"messageId\":\"messageId\","
+                + "\"canBeVoted\":true,\"relatedContent\":{\"title\":\"title\",\"content\":[{\"title\":\"title\",\"url\":"
+                + "\"url\",\"body\":\"body\"}]},\"followUp\":{\"text\":\"text\",\"options\":[{\"pillText\":\"Click me\",\""
+                + "prompt\":\"Test prompt\",\"disabled\":false,\"description\":\"Test description\",\"type\":\"button\"}]},"
+                + "\"codeReference\":[{\"licenseName\":\"licenseName\",\"repository\":\"repository\",\"url\":\"url\","
+                + "\"recommendationContentSpan\":{\"start\":1,\"end\":2},\"information\":\"information\"}]},\"isPartialResult\":true}";
+
+        ChatUIInboundCommand deserializedResult = objectMapper.readValue(json, ChatUIInboundCommand.class);
+
+        assertNotNull(deserializedResult.params());
+        assertEquals(command, deserializedResult.command());
+        assertEquals(tabId, deserializedResult.tabId());
+        assertEquals(isPartialResult, deserializedResult.isPartialResult());
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, ChatUIInboundCommand.class));
+    }
+
+    @Test
+    void testCreateGenericCommand() {
+        GenericCommandParams genericParams = new GenericCommandParams(tabId, selection, triggerType,
+                ChatUIInboundCommandName.GenericCommand.getValue());
+
+        ChatUIInboundCommand chatUiInboundCommand = ChatUIInboundCommand.createGenericCommand(genericParams);
+
+        assertNotNull(chatUiInboundCommand);
+        assertEquals(ChatUIInboundCommandName.GenericCommand.getValue(), chatUiInboundCommand.command());
+        assertNull(chatUiInboundCommand.tabId());
+        assertEquals(genericParams, chatUiInboundCommand.params());
+        assertNull(chatUiInboundCommand.isPartialResult());
+    }
+
+    @Test
+    void testCreateSendToPromptCommand() {
+        SendToPromptParams promptParams = new SendToPromptParams(selection, triggerType);
+
+        ChatUIInboundCommand chatUiInboundCommand = ChatUIInboundCommand.createSendToPromptCommand(promptParams);
+
+        assertNotNull(chatUiInboundCommand);
+        assertEquals(ChatUIInboundCommandName.SendToPrompt.getValue(), chatUiInboundCommand.command());
+        assertNull(chatUiInboundCommand.tabId());
+        assertEquals(promptParams, chatUiInboundCommand.params());
+        assertNull(chatUiInboundCommand.isPartialResult());
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/CopyToClipboardParamsTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/CopyToClipboardParamsTest.java
@@ -1,0 +1,99 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class CopyToClipboardParamsTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String tabId = "tabId";
+    private final String messageId = "messageId";
+    private final String code = "code";
+    private final String type = "type";
+
+    private final String licenseName = "licenseName";
+    private final String repository = "repository";
+    private final String url = "url";
+
+    private final Integer startLine = 1;
+    private final Integer endLine = 2;
+    private final RecommendationContentSpan recommendationSpan = new RecommendationContentSpan(startLine, endLine);
+
+    private final String information = "information";
+    private final ReferenceTrackerInformation referenceTrackerInformation = new ReferenceTrackerInformation(licenseName,
+            repository, url, recommendationSpan, information);
+
+    private final ReferenceTrackerInformation[] referenceTrackerInformationList = new ReferenceTrackerInformation[] {
+            referenceTrackerInformation};
+
+    private final String eventId = "eventId";
+    private final Integer codeBlockIndex = 0;
+    private final Integer totalCodeBlocks = 1;
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        CopyToClipboardParams copyToClipboardParams = new CopyToClipboardParams(tabId, messageId, code, type,
+                referenceTrackerInformationList, eventId, codeBlockIndex, totalCodeBlocks);
+
+        assertEquals(tabId, copyToClipboardParams.tabId());
+        assertEquals(messageId, copyToClipboardParams.messageId());
+        assertEquals(code, copyToClipboardParams.code());
+        assertEquals(type, copyToClipboardParams.type());
+        assertEquals(referenceTrackerInformationList, copyToClipboardParams.referenceTrackerInformation());
+        assertEquals(eventId, copyToClipboardParams.eventId());
+        assertEquals(codeBlockIndex, copyToClipboardParams.codeBlockIndex());
+        assertEquals(totalCodeBlocks, copyToClipboardParams.totalCodeBlocks());
+    }
+
+    @Test
+    void testJsonSerialization() throws Exception {
+        CopyToClipboardParams copyToClipboardParams = new CopyToClipboardParams(tabId, messageId, code, type,
+                referenceTrackerInformationList, eventId, codeBlockIndex, totalCodeBlocks);
+
+        String serializedObject = objectMapper.writeValueAsString(copyToClipboardParams);
+
+        assertEquals("{\"tabId\":\"tabId\",\"messageId\":\"messageId\",\"code\":\"code\",\"type\":\"type\",\""
+                + "referenceTrackerInformation\":[{\"licenseName\":\"licenseName\",\"repository\":\"repository\","
+                + "\"url\":\"url\",\"recommendationContentSpan\":{\"start\":1,\"end\":2},\"information\":"
+                + "\"information\"}],\"eventId\":\"eventId\",\"codeBlockIndex\":0,\"totalCodeBlocks\":1}",
+                serializedObject);
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"tabId\":\"tabId\",\"messageId\":\"messageId\",\"code\":\"code\",\"type\":\"type\",\""
+                + "referenceTrackerInformation\":[{\"licenseName\":\"licenseName\",\"repository\":\"repository\","
+                + "\"url\":\"url\",\"recommendationContentSpan\":{\"start\":1,\"end\":2},\"information\":"
+                + "\"information\"}],\"eventId\":\"eventId\",\"codeBlockIndex\":0,\"totalCodeBlocks\":1}";
+
+        CopyToClipboardParams deserializedResult = objectMapper.readValue(json, CopyToClipboardParams.class);
+
+        assertEquals(tabId, deserializedResult.tabId());
+        assertEquals(messageId, deserializedResult.messageId());
+        assertEquals(code, deserializedResult.code());
+        assertEquals(type, deserializedResult.type());
+        assertEquals(1, deserializedResult.referenceTrackerInformation().length);
+        assertNotNull(deserializedResult.referenceTrackerInformation()[0]);
+        assertEquals(eventId, deserializedResult.eventId());
+        assertEquals(codeBlockIndex, deserializedResult.codeBlockIndex());
+        assertEquals(totalCodeBlocks, deserializedResult.totalCodeBlocks());
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, CopyToClipboardParams.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/CursorStateTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/CursorStateTest.java
@@ -1,0 +1,63 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class CursorStateTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final Position startPosition = new Position(0, 0);
+    private final Position endPosition = new Position(100, 100);
+    private final Range range = new Range(startPosition, endPosition);
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        CursorState cursorState = new CursorState(range);
+
+        assertEquals(startPosition.getLine(), cursorState.range().getStart().getLine());
+        assertEquals(startPosition.getCharacter(), cursorState.range().getStart().getCharacter());
+        assertEquals(endPosition.getLine(), cursorState.range().getEnd().getLine());
+        assertEquals(endPosition.getCharacter(), cursorState.range().getEnd().getCharacter());
+    }
+
+    @Test
+    void testJsonSerialization() throws Exception {
+        CursorState cursorState = new CursorState(range);
+
+        String serializedObject = objectMapper.writeValueAsString(cursorState);
+
+        assertEquals("{\"range\":{\"start\":{\"line\":0,\"character\":0},\"end\":{\"line\":100,\"character\":100}}}",
+                serializedObject);
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"range\":{\"start\":{\"line\":0,\"character\":0},\"end\":{\"line\":100,\"character\":100}}}";
+
+        CursorState deserializedResult = objectMapper.readValue(json, CursorState.class);
+
+        assertEquals(startPosition.getLine(), deserializedResult.range().getStart().getLine());
+        assertEquals(startPosition.getCharacter(), deserializedResult.range().getStart().getCharacter());
+        assertEquals(endPosition.getLine(), deserializedResult.range().getEnd().getLine());
+        assertEquals(endPosition.getCharacter(), deserializedResult.range().getEnd().getCharacter());
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, CursorState.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/EncryptedChatParamsTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/EncryptedChatParamsTest.java
@@ -1,0 +1,55 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class EncryptedChatParamsTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String message = "message";
+    private final String partialResultToken = "partialResultToken";
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        EncryptedChatParams encryptedChatParams = new EncryptedChatParams(message, partialResultToken);
+
+        assertEquals(message, encryptedChatParams.message());
+        assertEquals(partialResultToken, encryptedChatParams.partialResultToken());
+    }
+
+    @Test
+    void testJsonSerialization() throws Exception {
+        EncryptedChatParams encryptedChatParams = new EncryptedChatParams(message, partialResultToken);
+
+        String serializedObject = objectMapper.writeValueAsString(encryptedChatParams);
+
+        assertEquals("{\"message\":\"message\",\"partialResultToken\":\"partialResultToken\"}", serializedObject);
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"message\":\"message\",\"partialResultToken\":\"partialResultToken\"}";
+
+        EncryptedChatParams deserializedResult = objectMapper.readValue(json, EncryptedChatParams.class);
+
+        assertEquals(message, deserializedResult.message());
+        assertEquals(partialResultToken, deserializedResult.partialResultToken());
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, EncryptedChatParams.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/EncryptedQuickActionParamsTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/EncryptedQuickActionParamsTest.java
@@ -1,0 +1,57 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class EncryptedQuickActionParamsTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String message = "message";
+    private final String partialResultToken = "partialResultToken";
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        EncryptedQuickActionParams encryptedQuickActionParams = new EncryptedQuickActionParams(message,
+                partialResultToken);
+
+        assertEquals(message, encryptedQuickActionParams.message());
+        assertEquals(partialResultToken, encryptedQuickActionParams.partialResultToken());
+    }
+
+    @Test
+    void testJsonSerialization() throws Exception {
+        EncryptedQuickActionParams encryptedQuickActionParams = new EncryptedQuickActionParams(message,
+                partialResultToken);
+
+        String serializedObject = objectMapper.writeValueAsString(encryptedQuickActionParams);
+
+        assertEquals("{\"message\":\"message\",\"partialResultToken\":\"partialResultToken\"}", serializedObject);
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"message\":\"message\",\"partialResultToken\":\"partialResultToken\"}";
+
+        EncryptedQuickActionParams deserializedResult = objectMapper.readValue(json, EncryptedQuickActionParams.class);
+
+        assertEquals(message, deserializedResult.message());
+        assertEquals(partialResultToken, deserializedResult.partialResultToken());
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, EncryptedQuickActionParams.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/ErrorParamsTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/ErrorParamsTest.java
@@ -1,0 +1,63 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ErrorParamsTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String tabId = "tabId";
+    private final String triggerType = "triggerType";
+    private final String message = "message";
+    private final String title = "title";
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        ErrorParams errorParams = new ErrorParams(tabId, triggerType, message, title);
+
+        assertEquals(tabId, errorParams.tabId());
+        assertEquals(triggerType, errorParams.triggerType());
+        assertEquals(message, errorParams.message());
+        assertEquals(title, errorParams.title());
+    }
+
+    @Test
+    void testJsonSerialization() throws Exception {
+        ErrorParams errorParams = new ErrorParams(tabId, triggerType, message, title);
+
+        String serializedObject = objectMapper.writeValueAsString(errorParams);
+
+        assertEquals(
+                "{\"tabId\":\"tabId\",\"triggerType\":\"triggerType\",\"message\":\"message\",\"title\":\"title\"}",
+                serializedObject);
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"tabId\":\"tabId\",\"triggerType\":\"triggerType\",\"message\":\"message\",\"title\":\"title\"}";
+
+        ErrorParams deserializedResult = objectMapper.readValue(json, ErrorParams.class);
+
+        assertEquals(tabId, deserializedResult.tabId());
+        assertEquals(triggerType, deserializedResult.triggerType());
+        assertEquals(message, deserializedResult.message());
+        assertEquals(title, deserializedResult.title());
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, ErrorParams.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/FeedbackParamsTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/FeedbackParamsTest.java
@@ -1,0 +1,67 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class FeedbackParamsTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String tabId = "tabId";
+    private final String eventId = "eventId";
+
+    private final String messageId = "messageId";
+    private final String selectedOption = "selectedOption";
+    private final String comment = "comment";
+    private final FeedbackPayload feedbackPayload = new FeedbackPayload(messageId, tabId, selectedOption, comment);
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        FeedbackParams feedbackParams = new FeedbackParams(tabId, eventId, feedbackPayload);
+
+        assertEquals(tabId, feedbackParams.tabId());
+        assertEquals(eventId, feedbackParams.eventId());
+        assertNotNull(feedbackParams.feedbackPayload());
+    }
+
+    @Test
+    void testJsonSerialization() throws Exception {
+        FeedbackParams feedbackParams = new FeedbackParams(tabId, eventId, feedbackPayload);
+
+        String serializedObject = objectMapper.writeValueAsString(feedbackParams);
+
+        assertEquals(
+                "{\"tabId\":\"tabId\",\"eventId\":\"eventId\",\"feedbackPayload\":{\"messageId\":\"messageId\",\"tabId\":\"tabId\""
+                        + ",\"selectedOption\":\"selectedOption\",\"comment\":\"comment\"}}",
+                serializedObject);
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"tabId\":\"tabId\",\"eventId\":\"eventId\",\"feedbackPayload\":{\"messageId\":\"messageId\","
+                + "\"tabId\":\"tabId\",\"selectedOption\":\"selectedOption\",\"comment\":\"comment\"}}";
+
+        FeedbackParams deserializedResult = objectMapper.readValue(json, FeedbackParams.class);
+
+        assertEquals(tabId, deserializedResult.tabId());
+        assertEquals(eventId, deserializedResult.eventId());
+        assertNotNull(deserializedResult.feedbackPayload());
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, FeedbackParams.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/FeedbackPayloadTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/FeedbackPayloadTest.java
@@ -1,0 +1,63 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class FeedbackPayloadTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String messageId = "messageId";
+    private final String tabId = "tabId";
+    private final String selectedOption = "selectedOption";
+    private final String comment = "comment";
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        FeedbackPayload feedbackPayload = new FeedbackPayload(messageId, tabId, selectedOption, comment);
+
+        assertEquals(messageId, feedbackPayload.messageId());
+        assertEquals(tabId, feedbackPayload.tabId());
+        assertEquals(selectedOption, feedbackPayload.selectedOption());
+        assertEquals(comment, feedbackPayload.comment());
+    }
+
+    @Test
+    void testJsonSerialization() throws Exception {
+        FeedbackPayload feedbackPayload = new FeedbackPayload(messageId, tabId, selectedOption, comment);
+
+        String serializedObject = objectMapper.writeValueAsString(feedbackPayload);
+
+        assertEquals(
+                "{\"messageId\":\"messageId\",\"tabId\":\"tabId\",\"selectedOption\":\"selectedOption\",\"comment\":\"comment\"}",
+                serializedObject);
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"messageId\":\"messageId\",\"tabId\":\"tabId\",\"selectedOption\":\"selectedOption\",\"comment\":\"comment\"}";
+
+        FeedbackPayload deserializedResult = objectMapper.readValue(json, FeedbackPayload.class);
+
+        assertEquals(messageId, deserializedResult.messageId());
+        assertEquals(tabId, deserializedResult.tabId());
+        assertEquals(selectedOption, deserializedResult.selectedOption());
+        assertEquals(comment, deserializedResult.comment());
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, FeedbackPayload.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/FollowUpClickParamsTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/FollowUpClickParamsTest.java
@@ -1,0 +1,69 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class FollowUpClickParamsTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String tabId = "tabId";
+    private final String messageId = "messageId";
+
+    private final String pillText = "Click me";
+    private final String prompt = "Test prompt";
+    private final Boolean disabled = false;
+    private final String description = "Test description";
+    private final String type = "button";
+    private final ChatItemAction chatItemAction = new ChatItemAction(pillText, prompt, disabled, description, type);
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        FollowUpClickParams followUpClickParams = new FollowUpClickParams(tabId, messageId, chatItemAction);
+
+        assertEquals(tabId, followUpClickParams.tabId());
+        assertEquals(messageId, followUpClickParams.messageId());
+        assertNotNull(followUpClickParams.followUp());
+    }
+
+    @Test
+    void testJsonSerialization() throws Exception {
+        FollowUpClickParams followUpClickParams = new FollowUpClickParams(tabId, messageId, chatItemAction);
+
+        String serializedObject = objectMapper.writeValueAsString(followUpClickParams);
+
+        assertEquals(
+                "{\"tabId\":\"tabId\",\"messageId\":\"messageId\",\"followUp\":{\"pillText\":\"Click me\",\"prompt\":\"Test prompt\",\"disabled\""
+                        + ":false,\"description\":\"Test description\",\"type\":\"button\"}}",
+                serializedObject);
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"tabId\":\"tabId\",\"messageId\":\"messageId\",\"followUp\":{\"pillText\":\"Click me\",\"prompt\":\"Test prompt\",\"disabled\""
+                + ":false,\"description\":\"Test description\",\"type\":\"button\"}}";
+
+        FollowUpClickParams deserializedResult = objectMapper.readValue(json, FollowUpClickParams.class);
+
+        assertEquals(tabId, deserializedResult.tabId());
+        assertEquals(messageId, deserializedResult.messageId());
+        assertNotNull(deserializedResult.followUp());
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, FollowUpClickParams.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/FollowUpTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/FollowUpTest.java
@@ -1,0 +1,69 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class FollowUpTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String pillText = "Click me";
+    private final String prompt = "Test prompt";
+    private final Boolean disabled = false;
+    private final String description = "Test description";
+    private final String type = "button";
+    private final ChatItemAction chatItemAction = new ChatItemAction(pillText, prompt, disabled, description, type);
+
+    private final String text = "text";
+    private final ChatItemAction[] options = new ChatItemAction[] {chatItemAction};
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        FollowUp followUp = new FollowUp(text, options);
+
+        assertEquals(text, followUp.text());
+        assertEquals(1, followUp.options().length);
+        assertNotNull(followUp.options()[0]);
+    }
+
+    @Test
+    void testJsonSerialization() throws Exception {
+        FollowUp followUp = new FollowUp(text, options);
+
+        String serializedObject = objectMapper.writeValueAsString(followUp);
+
+        assertEquals(
+                "{\"text\":\"text\",\"options\":[{\"pillText\":\"Click me\",\"prompt\":\"Test prompt\",\"disabled\":false,"
+                        + "\"description\":\"Test description\",\"type\":\"button\"}]}",
+                serializedObject);
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"text\":\"text\",\"options\":[{\"pillText\":\"Click me\",\"prompt\":\"Test prompt\",\"disabled\":false,"
+                + "\"description\":\"Test description\",\"type\":\"button\"}]}";
+
+        FollowUp deserializedResult = objectMapper.readValue(json, FollowUp.class);
+
+        assertEquals(text, deserializedResult.text());
+        assertEquals(1, deserializedResult.options().length);
+        assertNotNull(deserializedResult.options()[0]);
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, FollowUp.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/GenericCommandParamsTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/GenericCommandParamsTest.java
@@ -1,0 +1,65 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class GenericCommandParamsTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String tabId = "tabId";
+    private final String selection = "selection";
+    private final String triggerType = "triggerType";
+    private final String genericCommand = "genericCommand";
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        GenericCommandParams genericCommandParams = new GenericCommandParams(tabId, selection, triggerType,
+                genericCommand);
+
+        assertEquals(tabId, genericCommandParams.tabId());
+        assertEquals(selection, genericCommandParams.selection());
+        assertEquals(triggerType, genericCommandParams.triggerType());
+        assertEquals(genericCommand, genericCommandParams.genericCommand());
+    }
+
+    @Test
+    void testJsonSerialization() throws Exception {
+        GenericCommandParams genericCommandParams = new GenericCommandParams(tabId, selection, triggerType,
+                genericCommand);
+
+        String serializedObject = objectMapper.writeValueAsString(genericCommandParams);
+
+        assertEquals(
+                "{\"tabId\":\"tabId\",\"selection\":\"selection\",\"triggerType\":\"triggerType\",\"genericCommand\":\"genericCommand\"}",
+                serializedObject);
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"tabId\":\"tabId\",\"selection\":\"selection\",\"triggerType\":\"triggerType\",\"genericCommand\":\"genericCommand\"}";
+
+        GenericCommandParams deserializedResult = objectMapper.readValue(json, GenericCommandParams.class);
+
+        assertEquals(tabId, deserializedResult.tabId());
+        assertEquals(selection, deserializedResult.selection());
+        assertEquals(triggerType, deserializedResult.triggerType());
+        assertEquals(genericCommand, deserializedResult.genericCommand());
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, GenericCommandParams.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/GenericCommandVerbTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/GenericCommandVerbTest.java
@@ -1,0 +1,41 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class GenericCommandVerbTest {
+
+    @Test
+    void testGetValue() {
+        assertEquals("Explain", GenericCommandVerb.Explain.getValue());
+        assertEquals("Refactor", GenericCommandVerb.Refactor.getValue());
+        assertEquals("Fix", GenericCommandVerb.Fix.getValue());
+        assertEquals("Optimize", GenericCommandVerb.Optimize.getValue());
+    }
+
+    @Test
+    void testToString() {
+        assertEquals("Explain", GenericCommandVerb.Explain.toString());
+        assertEquals("Refactor", GenericCommandVerb.Refactor.toString());
+        assertEquals("Fix", GenericCommandVerb.Fix.toString());
+        assertEquals("Optimize", GenericCommandVerb.Optimize.toString());
+    }
+
+    @Test
+    void testToStringEqualsGetValue() {
+        for (ChatUIInboundCommandName command : ChatUIInboundCommandName.values()) {
+            assertEquals(command.getValue(), command.toString());
+        }
+    }
+
+    @Test
+    void testInvalidEnum() {
+        assertThrows(IllegalArgumentException.class, () -> ChatUIInboundCommandName.valueOf("NonExistentCommand"));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/GenericTabParamsTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/GenericTabParamsTest.java
@@ -1,0 +1,52 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class GenericTabParamsTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String tabId = "tabId";
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        GenericTabParams genericTabParams = new GenericTabParams(tabId);
+
+        assertEquals(tabId, genericTabParams.tabId());
+    }
+
+    @Test
+    void testJsonSerialization() throws Exception {
+        GenericTabParams genericTabParams = new GenericTabParams(tabId);
+
+        String serializedObject = objectMapper.writeValueAsString(genericTabParams);
+
+        assertEquals("{\"tabId\":\"tabId\"}", serializedObject);
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"tabId\":\"tabId\"}";
+
+        GenericTabParams deserializedResult = objectMapper.readValue(json, GenericTabParams.class);
+
+        assertEquals(tabId, deserializedResult.tabId());
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, GenericTabParams.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/InfoLinkClickParamsTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/InfoLinkClickParamsTest.java
@@ -1,0 +1,64 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class InfoLinkClickParamsTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String tabId = "tabId";
+    private final String link = "link";
+    private final String eventId = "eventId";
+
+    @Test
+    void testRecordSettersAndGetters() {
+        InfoLinkClickParams infoLinkClickParams = new InfoLinkClickParams();
+        infoLinkClickParams.setTabId(tabId);
+        infoLinkClickParams.setLink(link);
+        infoLinkClickParams.setEventId(eventId);
+
+        assertEquals(tabId, infoLinkClickParams.getTabId());
+        assertEquals(link, infoLinkClickParams.getLink());
+        assertEquals(eventId, infoLinkClickParams.getEventId());
+    }
+
+    @Test
+    void testJsonSerialization() throws Exception {
+        InfoLinkClickParams infoLinkClickParams = new InfoLinkClickParams();
+        infoLinkClickParams.setTabId(tabId);
+        infoLinkClickParams.setLink(link);
+        infoLinkClickParams.setEventId(eventId);
+
+        String serializedObject = objectMapper.writeValueAsString(infoLinkClickParams);
+
+        assertEquals("{\"tabId\":\"tabId\",\"link\":\"link\",\"eventId\":\"eventId\"}", serializedObject);
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"tabId\":\"tabId\",\"link\":\"link\",\"eventId\":\"eventId\"}";
+
+        InfoLinkClickParams deserializedResult = objectMapper.readValue(json, InfoLinkClickParams.class);
+
+        assertEquals(tabId, deserializedResult.getTabId());
+        assertEquals(link, deserializedResult.getLink());
+        assertEquals(eventId, deserializedResult.getEventId());
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, InfoLinkClickParams.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/InsertToCursorPositionParamsTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/InsertToCursorPositionParamsTest.java
@@ -1,0 +1,94 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class InsertToCursorPositionParamsTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String tabId = "tabId";
+    private final String messageId = "messageId";
+    private final String code = "code";
+    private final String type = "type";
+
+    private final String licenseName = "licenseName";
+    private final String repository = "repository";
+    private final String url = "url";
+
+    private final Integer startLine = 1;
+    private final Integer endLine = 2;
+    private final RecommendationContentSpan recommendationSpan = new RecommendationContentSpan(startLine, endLine);
+
+    private final String textDocumentUri = "test/file.txt";
+    private final TextDocumentIdentifier textDocumentIdentifier = new TextDocumentIdentifier(textDocumentUri);
+
+    private final String information = "information";
+    private final ReferenceTrackerInformation referenceTrackerInformation = new ReferenceTrackerInformation(licenseName,
+            repository, url, recommendationSpan, information);
+
+    private final ReferenceTrackerInformation[] referenceTrackerInformationList = new ReferenceTrackerInformation[] {
+            referenceTrackerInformation};
+
+    private final String eventId = "eventId";
+    private final Integer codeBlockIndex = 0;
+    private final Integer totalCodeBlocks = 1;
+
+    private final Position startPosition = new Position(0, 0);
+    private final Position endPosition = new Position(100, 100);
+    private final Range range = new Range(startPosition, endPosition);
+    private final CursorState cursorState = new CursorState(range);
+    private final List<CursorState> cursorStateList = List.of(cursorState);
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        InsertToCursorPositionParams insertToCursorPositionParams = new InsertToCursorPositionParams(tabId, messageId,
+                code, type, referenceTrackerInformationList, eventId, codeBlockIndex, totalCodeBlocks,
+                textDocumentIdentifier, cursorState);
+        insertToCursorPositionParams.setCursorState(cursorStateList);
+        insertToCursorPositionParams.setTextDocument(textDocumentIdentifier);
+
+        assertEquals(code, insertToCursorPositionParams.getCode());
+        assertEquals(cursorStateList, insertToCursorPositionParams.getCursorState());
+        assertEquals(textDocumentIdentifier, insertToCursorPositionParams.getTextDocument());
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"tabId\":\"tabId\",\"messageId\":\"messageId\",\"code\":\"code\",\"type\":\"type\",\""
+                + "referenceTrackerInformation\":[{\"licenseName\":\"licenseName\",\"repository\":\"repository\","
+                + "\"url\":\"url\",\"recommendationContentSpan\":{\"start\":1,\"end\":2},\"information\":"
+                + "\"information\"}],\"eventId\":\"eventId\",\"codeBlockIndex\":0,\"totalCodeBlocks\":1,"
+                + "\"textDocument\": {\"uri\": \"test/file.txt\"},\"cursorState\": {\"range\": {\"start\": {"
+                + "\"line\": 0,\"character\": 0},\"end\": {\"line\": 100,\"character\": 100}}}}";
+
+        InsertToCursorPositionParams deserializedResult = objectMapper.readValue(json,
+                InsertToCursorPositionParams.class);
+
+        assertEquals(code, deserializedResult.getCode());
+        assertNull(deserializedResult.getCursorState());
+        assertNull(deserializedResult.getTextDocument());
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, InsertToCursorPositionParams.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/QChatCssVariableTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/QChatCssVariableTest.java
@@ -1,0 +1,94 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class QChatCssVariableTest {
+
+    @Test
+    void testEnumValues() {
+        assertEquals(27, QChatCssVariable.values().length);
+    }
+
+    @Test
+    void testTextColorValues() {
+        assertEquals("--mynah-color-text-default", QChatCssVariable.TextColorDefault.getValue());
+        assertEquals("--mynah-color-text-strong", QChatCssVariable.TextColorStrong.getValue());
+        assertEquals("--mynah-color-text-weak", QChatCssVariable.TextColorWeak.getValue());
+        assertEquals("--mynah-color-text-link", QChatCssVariable.TextColorLink.getValue());
+        assertEquals("--mynah-color-text-input", QChatCssVariable.TextColorInput.getValue());
+    }
+
+    @Test
+    void testLayoutValues() {
+        assertEquals("--mynah-color-bg", QChatCssVariable.Background.getValue());
+        assertEquals("--mynah-color-tab-active", QChatCssVariable.TabActive.getValue());
+        assertEquals("--mynah-color-border-default", QChatCssVariable.BorderDefault.getValue());
+        assertEquals("--mynah-color-toggle", QChatCssVariable.ColorToggle.getValue());
+    }
+
+    @Test
+    void testSyntaxValues() {
+        assertEquals("--mynah-color-syntax-bg", QChatCssVariable.SyntaxBackground.getValue());
+        assertEquals("--mynah-color-syntax-variable", QChatCssVariable.SyntaxVariable.getValue());
+        assertEquals("--mynah-color-syntax-function", QChatCssVariable.SyntaxFunction.getValue());
+        assertEquals("--mynah-color-syntax-operator", QChatCssVariable.SyntaxOperator.getValue());
+        assertEquals("--mynah-color-syntax-attr-value", QChatCssVariable.SyntaxAttributeValue.getValue());
+        assertEquals("--mynah-color-syntax-attr", QChatCssVariable.SyntaxAttribute.getValue());
+        assertEquals("--mynah-color-syntax-property", QChatCssVariable.SyntaxProperty.getValue());
+        assertEquals("--mynah-color-syntax-comment", QChatCssVariable.SyntaxComment.getValue());
+        assertEquals("--mynah-color-syntax-code", QChatCssVariable.SyntaxCode.getValue());
+    }
+
+    @Test
+    void testStatusValues() {
+        assertEquals("--mynah-color-status-info", QChatCssVariable.StatusInfo.getValue());
+        assertEquals("--mynah-color-status-success", QChatCssVariable.StatusSuccess.getValue());
+        assertEquals("--mynah-color-status-warning", QChatCssVariable.StatusWarning.getValue());
+        assertEquals("--mynah-color-status-error", QChatCssVariable.StatusError.getValue());
+    }
+
+    @Test
+    void testButtonValues() {
+        assertEquals("--mynah-color-button", QChatCssVariable.ButtonBackground.getValue());
+        assertEquals("--mynah-color-button-reverse", QChatCssVariable.ButtonForeground.getValue());
+    }
+
+    @Test
+    void testAlternateValues() {
+        assertEquals("--mynah-color-alternate", QChatCssVariable.AlternateBackground.getValue());
+        assertEquals("--mynah-color-alternate-reverse", QChatCssVariable.AlternateForeground.getValue());
+    }
+
+    @Test
+    void testCardValues() {
+        assertEquals("--mynah-card-bg", QChatCssVariable.CardBackground.getValue());
+    }
+
+    @Test
+    void testInvalidEnum() {
+        assertThrows(IllegalArgumentException.class, () -> QChatCssVariable.valueOf("NonExistentVariable"));
+    }
+
+    @Test
+    void testNullValue() {
+        for (QChatCssVariable variable : QChatCssVariable.values()) {
+            assertNotNull(variable.getValue());
+        }
+    }
+
+    @Test
+    void testCssVariableFormat() {
+        for (QChatCssVariable variable : QChatCssVariable.values()) {
+            assertTrue(variable.getValue().startsWith("--mynah-"));
+        }
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/QuickActionParamsTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/QuickActionParamsTest.java
@@ -1,0 +1,52 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class QuickActionParamsTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String tabId = "tabId";
+    private final String quickAction = "quickAction";
+    private final String prompt = "prompt";
+    private final String partialResultToken = "partialResultToken";
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        QuickActionParams quickActionParams = new QuickActionParams(tabId, quickAction, prompt);
+        quickActionParams.setPartialResultToken(partialResultToken);
+
+        assertEquals(tabId, quickActionParams.getTabId());
+        assertEquals(quickAction, quickActionParams.getQuickAction());
+        assertEquals(prompt, quickActionParams.getPrompt());
+        assertEquals(partialResultToken, quickActionParams.getPartialResultToken());
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"tabId\":\"tabId\",\"quickAction\":\"quickAction\",\"prompt\":\"prompt\",\"partialResultToken\":\"partialResultToken\"}";
+
+        QuickActionParams deserializedResult = objectMapper.readValue(json, QuickActionParams.class);
+
+        assertEquals(tabId, deserializedResult.getTabId());
+        assertEquals(quickAction, deserializedResult.getQuickAction());
+        assertEquals(prompt, deserializedResult.getPrompt());
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, QuickActionParams.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/ReferenceTrackerInformationTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/ReferenceTrackerInformationTest.java
@@ -1,0 +1,75 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ReferenceTrackerInformationTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String licenseName = "licenseName";
+    private final String repository = "repository";
+    private final String url = "url";
+
+    private final Integer startLine = 1;
+    private final Integer endLine = 2;
+    private final RecommendationContentSpan recommendationSpan = new RecommendationContentSpan(startLine, endLine);
+
+    private final String information = "information";
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        ReferenceTrackerInformation referenceTrackerInformation = new ReferenceTrackerInformation(licenseName,
+                repository, url, recommendationSpan, information);
+
+        assertEquals(licenseName, referenceTrackerInformation.licenseName());
+        assertEquals(repository, referenceTrackerInformation.repository());
+        assertEquals(url, referenceTrackerInformation.url());
+        assertEquals(recommendationSpan, referenceTrackerInformation.recommendationContentSpan());
+        assertEquals(information, referenceTrackerInformation.information());
+    }
+
+    @Test
+    void testJsonSerialization() throws Exception {
+        ReferenceTrackerInformation referenceTrackerInformation = new ReferenceTrackerInformation(licenseName,
+                repository, url, recommendationSpan, information);
+
+        String serializedObject = objectMapper.writeValueAsString(referenceTrackerInformation);
+
+        assertEquals(
+                "{\"licenseName\":\"licenseName\",\"repository\":\"repository\",\"url\":\"url\",\"recommendationContentSpan\":{\"start\""
+                        + ":1,\"end\":2},\"information\":\"information\"}",
+                serializedObject);
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"licenseName\":\"licenseName\",\"repository\":\"repository\",\"url\":\"url\",\"recommendationContentSpan\":{\"start\""
+                + ":1,\"end\":2},\"information\":\"information\"}";
+
+        ReferenceTrackerInformation deserializedResult = objectMapper.readValue(json,
+                ReferenceTrackerInformation.class);
+
+        assertEquals(licenseName, deserializedResult.licenseName());
+        assertEquals(repository, deserializedResult.repository());
+        assertEquals(url, deserializedResult.url());
+        assertEquals(recommendationSpan, deserializedResult.recommendationContentSpan());
+        assertEquals(information, deserializedResult.information());
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, ReferenceTrackerInformation.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/RelatedContentTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/RelatedContentTest.java
@@ -1,0 +1,60 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class RelatedContentTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String title = "title";
+    private final SourceLink sourceLink = new SourceLink("title", "url", "body");
+    private final SourceLink[] sourceLinkArray = new SourceLink[] {sourceLink};
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        RelatedContent relatedContent = new RelatedContent(title, sourceLinkArray);
+
+        assertEquals(title, relatedContent.title());
+        assertEquals(1, relatedContent.content().length);
+        assertEquals(sourceLink, relatedContent.content()[0]);
+    }
+
+    @Test
+    void testJsonSerialization() throws Exception {
+        RelatedContent relatedContent = new RelatedContent(title, sourceLinkArray);
+
+        String serializedObject = objectMapper.writeValueAsString(relatedContent);
+
+        assertEquals("{\"title\":\"title\",\"content\":[{\"title\":\"title\",\"url\":\"url\",\"body\":\"body\"}]}",
+                serializedObject);
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"title\":\"title\",\"content\":[{\"title\":\"title\",\"url\":\"url\",\"body\":\"body\"}]}";
+
+        RelatedContent deserializedResult = objectMapper.readValue(json, RelatedContent.class);
+
+        assertEquals(title, deserializedResult.title());
+        assertEquals(1, deserializedResult.content().length);
+        assertNotNull(deserializedResult.content()[0]);
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, RelatedContent.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/SendToPromptParamsTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/SendToPromptParamsTest.java
@@ -1,0 +1,55 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class SendToPromptParamsTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String selection = "selection";
+    private final String triggerType = "triggerType";
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        SendToPromptParams sendToPromptParams = new SendToPromptParams(selection, triggerType);
+
+        assertEquals(selection, sendToPromptParams.selection());
+        assertEquals(triggerType, sendToPromptParams.triggerType());
+    }
+
+    @Test
+    void testJsonSerialization() throws Exception {
+        SendToPromptParams sendToPromptParams = new SendToPromptParams(selection, triggerType);
+
+        String serializedObject = objectMapper.writeValueAsString(sendToPromptParams);
+
+        assertEquals("{\"selection\":\"selection\",\"triggerType\":\"triggerType\"}", serializedObject);
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"selection\":\"selection\",\"triggerType\":\"triggerType\"}";
+
+        SendToPromptParams deserializedPrompt = objectMapper.readValue(json, SendToPromptParams.class);
+
+        assertEquals(selection, deserializedPrompt.selection());
+        assertEquals(triggerType, deserializedPrompt.triggerType());
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, SendToPromptParams.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/SourceLinkTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/SourceLinkTest.java
@@ -1,0 +1,58 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class SourceLinkTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String title = "title";
+    private final String url = "url";
+    private final String body = "body";
+
+    @Test
+    void testRecordConstructionAndGetters() {
+        SourceLink sourceLink = new SourceLink(title, url, body);
+
+        assertEquals(title, sourceLink.title());
+        assertEquals(url, sourceLink.url());
+        assertEquals(body, sourceLink.body());
+    }
+
+    @Test
+    void testJsonSerialization() throws Exception {
+        SourceLink sourceLink = new SourceLink(title, url, body);
+
+        String serializedObject = objectMapper.writeValueAsString(sourceLink);
+
+        assertEquals("{\"title\":\"title\",\"url\":\"url\",\"body\":\"body\"}", serializedObject);
+    }
+
+    @Test
+    void testJsonDeserialization() throws Exception {
+        String json = "{\"title\":\"title\",\"url\":\"url\",\"body\":\"body\"}";
+
+        SourceLink deserializedResult = objectMapper.readValue(json, SourceLink.class);
+
+        assertEquals(title, deserializedResult.title());
+        assertEquals(url, deserializedResult.url());
+        assertEquals(body, deserializedResult.body());
+    }
+
+    @Test
+    void testDeserializationException() throws Exception {
+        String json = "incorrectly formatted json";
+
+        assertThrows(JsonParseException.class, () -> objectMapper.readValue(json, SourceLink.class));
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/TriggerTypeTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/models/TriggerTypeTest.java
@@ -1,0 +1,45 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class TriggerTypeTest {
+
+    @Test
+    void testEnumValues() {
+        assertEquals(3, TriggerType.values().length);
+    }
+
+    @Test
+    void testGetValue() {
+        assertEquals("hotkeys", TriggerType.Hotkeys.getValue());
+        assertEquals("click", TriggerType.Click.getValue());
+        assertEquals("contextMenu", TriggerType.ContextMenu.getValue());
+    }
+
+    @Test
+    void testToString() {
+        for (TriggerType command : TriggerType.values()) {
+            assertEquals(command.getValue(), command.toString());
+        }
+    }
+
+    @Test
+    void testInvalidEnum() {
+        assertThrows(IllegalArgumentException.class, () -> TriggerType.valueOf("InvalidTrigger"));
+    }
+
+    @Test
+    void testNullValue() {
+        for (TriggerType type : TriggerType.values()) {
+            assertNotNull(type.getValue());
+        }
+    }
+
+}


### PR DESCRIPTION
*Description of changes:*
Added tests for chat models.

*Things to consider:*
- Need to figure out if we want to update the constructor to store all values parsed by the json object mapper. Some values are currently ignored in `ChatRequestParams` and `InsertToCursorPositionParams`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
