### PR TITLE
Fix null pointer exception caused by cursor state

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/models/ChatRequestParams.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/models/ChatRequestParams.java
@@ -24,7 +24,7 @@ public final class ChatRequestParams {
         this.tabId = tabId;
         this.prompt = prompt;
         this.textDocument = textDocument;
-        this.cursorState = List.of(cursorState);
+        this.cursorState = (cursorState != null) ? List.of(cursorState) : List.of();
     }
 
     public String getTabId() {


### PR DESCRIPTION
*Description of changes:*
List.of() won't accept a null value, so cursorState being null is causing serialization to fail and freezing up chat. Adds validation for null case to avoid exception

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
