### PR TITLE
Adjusts status bar label text

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/InlineQueryStatusBarContribution.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/InlineQueryStatusBarContribution.java
@@ -13,9 +13,9 @@ import software.aws.toolkits.eclipse.amazonq.util.QInvocationSession;
 
 public final class InlineQueryStatusBarContribution extends WorkbenchWindowControlContribution {
 
-    private static final String QUERY_STATUS   = "Q is querying...    ";
-    private static final String IDLE_STATUS    = "Q is ready          ";
-    private static final String PREVIEW_STATUS = "Q is previewing     ";
+    private static final String QUERY_STATUS   = "Amazon Q is querying...    ";
+    private static final String IDLE_STATUS    = "Amazon Q is ready          ";
+    private static final String PREVIEW_STATUS = "Amazon Q is previewing     ";
 
     private Label statusLabel;
 


### PR DESCRIPTION
*Issue #, if available:*
Adjusts status bar text from "Q" to "Amazon Q"

*Alignment:*
It may seem like the text is off but it is actually aligned with the rest of labels in eclipse:
<img width="998" alt="image" src="https://github.com/user-attachments/assets/8f23337b-41bf-4de0-9fa1-6bc9f948cb1d">

*Description of changes:*
- Changes status bar text from "Q" to "Amazon Q"

*Test:*
Idle:
<img width="1206" alt="image" src="https://github.com/user-attachments/assets/483f8137-4875-4c5e-a617-b42fb26410b8">

Querying:
<img width="1209" alt="image" src="https://github.com/user-attachments/assets/5223c83b-9363-4397-8368-a442403d7c6e">

Previewing:
<img width="1206" alt="image" src="https://github.com/user-attachments/assets/6b9e9fa6-7979-473c-854b-7780bf3f812f">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
