### PR TITLE
fix for lsp start up race condition preventing telemetry emission

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/LspProviderImpl.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/LspProviderImpl.java
@@ -50,8 +50,8 @@ public final class LspProviderImpl implements LspProvider {
             CompletableFuture<LanguageServer> future = futures.remove(AmazonQLspServer.class);
             if (future != null) {
                 future.complete(server);
-                emitInitializeMetric();
             }
+            emitInitializeMetric();
         }
     }
 


### PR DESCRIPTION
*Description of changes:*
In some cases, telemetry is not emitted if this process finishes too fast. Move metric outside of future condition to ensure emission happens regardless.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
