### PR TITLE
Remove slashes from user agent name

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServerBuilder.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServerBuilder.java
@@ -23,7 +23,7 @@ import software.aws.toolkits.eclipse.amazonq.telemetry.metadata.PluginClientMeta
 
 public class AmazonQLspServerBuilder extends Builder<AmazonQLspServer> {
 
-    private static final String USER_AGENT_CLIENT_NAME = "AmazonQ-For-Eclipse";
+    private static final String USER_AGENT_CLIENT_NAME = "AmazonQ For Eclipse";
     private static Launcher<AmazonQLspServer> launcher;
 
     @Override


### PR DESCRIPTION
*Description of changes:*
Flare apply this formatting themselves [here](https://github.com/aws/language-servers/blob/bc016ea18e818145851bb4ee035f2ee0be07aa26/server/aws-lsp-codewhisperer/src/language-server/utilities/telemetryUtils.ts#L27-L34). This value is also used during the sign in flow when prompting the user to provide permissions, exposing the slashes to the user, which this change will resolve.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
