### PR TITLE
Ghost text alignment fix windows linux

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/IQInlineSuggestionSegmentFactory.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/IQInlineSuggestionSegmentFactory.java
@@ -53,7 +53,7 @@ public final class IQInlineSuggestionSegmentFactory {
                 case CLOSE:
                     if (!unresolvedBrackets.isEmpty()) {
                         var closeBracket = new QInlineSuggestionCloseBracketSegment(startOffset + j, i,
-                                currentLine.substring(0, j), c);
+                                currentLine.substring(0, j), c, qSes.isMacOS());
                         var top = unresolvedBrackets.pop();
                         if (top.isAMatch(closeBracket)) {
                             top.pairUp(closeBracket);
@@ -70,7 +70,7 @@ public final class IQInlineSuggestionSegmentFactory {
             }
             distanceTraversed += sb.length() + 1; // plus one because we got rid of a \\R when we split it
             endOffset = startOffset + sb.length() - 1;
-            res.add(new QInlineSuggestionNormalSegment(startOffset, endOffset, i, sb.toString()));
+            res.add(new QInlineSuggestionNormalSegment(startOffset, endOffset, i, sb.toString(), qSes.isMacOS()));
         }
         return res;
     }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QInlineSuggestionCloseBracketSegment.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QInlineSuggestionCloseBracketSegment.java
@@ -7,6 +7,8 @@ import static software.aws.toolkits.eclipse.amazonq.util.QConstants.Q_INLINE_HIN
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.TextLayout;
+import org.eclipse.swt.widgets.Display;
 
 public final class QInlineSuggestionCloseBracketSegment implements IQInlineSuggestionSegment, IQInlineBracket {
     private QInlineSuggestionOpenBracketSegment openBracket;
@@ -15,13 +17,17 @@ public final class QInlineSuggestionCloseBracketSegment implements IQInlineSugge
     private int lineInSuggestion;
     private String text;
     private Font adjustedTypedFont;
+    private TextLayout layout;
+    private boolean isMacOS;
 
     public QInlineSuggestionCloseBracketSegment(final int caretOffset, final int lineInSuggestion, final String text,
-            final char symbol) {
+            final char symbol, final boolean isMacOS) {
         this.caretOffset = caretOffset;
         this.symbol = symbol;
         this.lineInSuggestion = lineInSuggestion;
         this.text = text;
+        this.layout = isMacOS ? null : new TextLayout(Display.getCurrent());
+        this.isMacOS = isMacOS;
 
         var qInvocationSessionInstance = QInvocationSession.getInstance();
         adjustedTypedFont = qInvocationSessionInstance.getBoldInlineFont();
@@ -57,25 +63,39 @@ public final class QInlineSuggestionCloseBracketSegment implements IQInlineSugge
         int invocationLine = widget.getLineAtOffset(invocationOffset);
         int lineHt = widget.getLineHeight();
         int fontHt = gc.getFontMetrics().getHeight();
-        // educated guess:
-        int endPadding = gc.getAdvanceWidth(symbol) / 4;
         y = (invocationLine + lineInSuggestion + 1) * lineHt - fontHt;
         x = gc.textExtent(text).x;
         if (lineInSuggestion == 0) {
             x += widget.getLocationAtOffset(invocationOffset).x;
         }
-
-        if (currentCaretOffset > openBracket.getRelevantOffset()) {
-            Color typedColor = widget.getForeground();
-            gc.setForeground(typedColor);
-            gc.setFont(adjustedTypedFont);
-        } else {
-            gc.setForeground(Q_INLINE_HINT_TEXT_COLOR);
-            gc.setFont(qInvocationSessionInstance.getInlineTextFont());
-        }
         int scrollOffsetY = widget.getTopPixel();
         y -= scrollOffsetY;
-        gc.drawText(String.valueOf(symbol), x, y, true);
+        String textToRender = String.valueOf(symbol);
+        if (currentCaretOffset > openBracket.getRelevantOffset()) {
+            Color typedColor = widget.getForeground();
+            if (isMacOS) {
+                gc.setForeground(typedColor);
+                gc.setFont(adjustedTypedFont);
+                gc.drawText(textToRender, x, y, false);
+            } else {
+                layout.setFont(adjustedTypedFont);
+                layout.setText(textToRender);
+                layout.setTabs(widget.getTabStops());
+                layout.draw(gc, x, y, 0, textToRender.length(), typedColor, null);
+            }
+        } else {
+            if (isMacOS) {
+                gc.setForeground(Q_INLINE_HINT_TEXT_COLOR);
+                gc.setFont(qInvocationSessionInstance.getInlineTextFont());
+                gc.drawText(textToRender, x, y, true);
+            } else {
+                layout.setFont(qInvocationSessionInstance.getInlineTextFont());
+                layout.setText(textToRender);
+                layout.setTabs(widget.getTabStops());
+                gc.setAlpha(127);
+                layout.draw(gc, x, y, 0, textToRender.length(), Q_INLINE_HINT_TEXT_COLOR, null);
+            }
+        }
     }
 
     @Override
@@ -112,5 +132,8 @@ public final class QInlineSuggestionCloseBracketSegment implements IQInlineSugge
 
     @Override
     public void cleanUp() {
+        if (layout != null) {
+            layout.dispose();
+        }
     }
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QInlineSuggestionNormalSegment.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QInlineSuggestionNormalSegment.java
@@ -8,6 +8,8 @@ import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.GlyphMetrics;
+import org.eclipse.swt.graphics.TextLayout;
+import org.eclipse.swt.widgets.Display;
 
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
 
@@ -17,13 +19,17 @@ public final class QInlineSuggestionNormalSegment implements IQInlineSuggestionS
     private int lineInSuggestion;
     private String text;
     private StyleRange styleRange = new StyleRange();
+    private TextLayout layout;
+    private boolean isMacOS;
 
     public QInlineSuggestionNormalSegment(final int startCaretPosition, final int endCaretPosition,
-            final int lineInSuggestion, final String text) {
+            final int lineInSuggestion, final String text, final boolean isMacOS) {
+        this.isMacOS = isMacOS;
         this.text = text;
         this.startCaretOffset = startCaretPosition;
         this.endCaretOffset = endCaretPosition;
         this.lineInSuggestion = lineInSuggestion;
+        this.layout = isMacOS ? null : new TextLayout(Display.getCurrent());
     }
 
     @Override
@@ -73,13 +79,23 @@ public final class QInlineSuggestionNormalSegment implements IQInlineSuggestionS
         int scrollOffsetY = widget.getTopPixel();
         y -= scrollOffsetY;
 
-        gc.setForeground(Q_INLINE_HINT_TEXT_COLOR);
-        gc.setFont(qInvocationSessionInstance.getInlineTextFont());
-        gc.drawText(textToRender, x, y, true);
+        if (!isMacOS) {
+            layout.setText(textToRender);
+            layout.setFont(qInvocationSessionInstance.getInlineTextFont());
+            layout.setTabs(widget.getTabStops());
+            layout.draw(gc, x, y);
+        } else {
+            gc.setForeground(Q_INLINE_HINT_TEXT_COLOR);
+            gc.setFont(qInvocationSessionInstance.getInlineTextFont());
+            gc.drawText(textToRender, x, y, true);
+        }
     }
 
     @Override
     public void cleanUp() {
+        if (layout != null) {
+            layout.dispose();
+        }
         QInvocationSession session = QInvocationSession.getInstance();
         if (!session.isActive()) {
             return;

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QInlineSuggestionNormalSegment.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QInlineSuggestionNormalSegment.java
@@ -83,6 +83,7 @@ public final class QInlineSuggestionNormalSegment implements IQInlineSuggestionS
             layout.setText(textToRender);
             layout.setFont(qInvocationSessionInstance.getInlineTextFont());
             layout.setTabs(widget.getTabStops());
+            gc.setAlpha(127);
             layout.draw(gc, x, y);
         } else {
             gc.setForeground(Q_INLINE_HINT_TEXT_COLOR);

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QInvocationSession.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QInvocationSession.java
@@ -36,6 +36,7 @@ public final class QInvocationSession extends QResource {
     private volatile QInvocationSessionState state = QInvocationSessionState.INACTIVE;
     private CaretMovementReason caretMovementReason = CaretMovementReason.UNEXAMINED;
     private boolean suggestionAccepted = false;
+    private boolean isMacOS;
 
     private QSuggestionsContext suggestionsContext = null;
 
@@ -60,6 +61,7 @@ public final class QInvocationSession extends QResource {
     // Private constructor to prevent instantiation
     private QInvocationSession() {
         // Initialization code here
+        isMacOS = System.getProperty("os.name").toLowerCase().contains("mac");
     }
 
     // Method to get the single instance
@@ -487,6 +489,10 @@ public final class QInvocationSession extends QResource {
 
     public Font getBoldInlineFont() {
         return inlineTextFontBold;
+    }
+
+    public boolean isMacOS() {
+        return isMacOS;
     }
 
     // Additional methods for the session can be added here


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-q-eclipse/issues/283

*Description of changes:*
- Adds logic to conditionally render ghost text depending on OS.

*Test:*
On windows:
<img width="1074" alt="Screenshot 2024-12-04 at 11 19 03 AM" src="https://github.com/user-attachments/assets/b883bbcc-dfc7-468c-ab13-de34f6968da2">

On mac (after the change. Nothing is changed but this is just here to show that this still functions like it did before):
<img width="672" alt="Screenshot 2024-12-04 at 11 20 40 AM" src="https://github.com/user-attachments/assets/fd766b7b-4688-45bf-a6ac-9f55c080e150">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
