### PR TITLE
Fix issue causing Amazon Q submenu to disappear

### DIFF
--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -387,6 +387,7 @@
                                 <equals value="org.eclipse.ui.DefaultTextEditor"/>
                                 <equals value="org.eclipse.jdt.ui.CompilationUnitEditor"/>
                                 <equals value="org.eclipse.ui.genericeditor.GenericEditor"/>
+                                <equals value="software.aws.toolkits.eclipse.amazonq.views.AmazonQChatWebview" />
                             </or>
                         </with>
                     </and>


### PR DESCRIPTION
*Description of changes:*
This PR adds the chat view to the eligible views that the menu should be displayed on, preventing the Q submenu from disappearing within the editor's context menu.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
