### PR TITLE
Fix typeahead backspace cleanup

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/JavaTypeaheadProcessor.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/JavaTypeaheadProcessor.java
@@ -32,7 +32,7 @@ public final class JavaTypeaheadProcessor implements IQInlineTypeaheadProcessor 
             final int currentDistanceTraversed, final IQInlineBracket[] brackets) {
         int numCharDeleted = inputLength;
         int paddingLength = 0;
-        for (int i = 1; i <= numCharDeleted; i++) {
+        for (int i = 1; i <= numCharDeleted && i <= currentDistanceTraversed; i++) {
             var bracket = brackets[currentDistanceTraversed - i];
             if (bracket != null) {
                 if ((bracket instanceof QInlineSuggestionOpenBracketSegment)

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QInlineInputListener.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QInlineInputListener.java
@@ -89,7 +89,7 @@ public final class QInlineInputListener implements IDocumentListener, VerifyKeyL
         List<IQInlineSuggestionSegment> segments = IQInlineSuggestionSegmentFactory.getSegmentsFromSuggestion(session);
         brackets = new IQInlineBracket[session.getCurrentSuggestion().getInsertText().length()];
         if (lineIdx < contentInLine.length()) {
-            rightCtxBuf = contentInLine.substring(lineIdx) + delimiter;
+            rightCtxBuf = contentInLine.substring(lineIdx);
         }
         int normalSegmentNum = 0;
         for (var segment : segments) {
@@ -174,10 +174,6 @@ public final class QInlineInputListener implements IDocumentListener, VerifyKeyL
             }
         }
         toAppend += rightCtxBuf;
-        if (rightCtxBuf.isEmpty()) {
-            toAppend += widget.getLineDelimiter();
-        }
-
         suggestionSegments.stream().forEach((segment) -> segment.cleanUp());
 
         int idx = distanceTraversed;
@@ -190,11 +186,8 @@ public final class QInlineInputListener implements IDocumentListener, VerifyKeyL
                 int startLineOffset = doc.getLineOffset(lineNumber);
                 int curLineInDoc = widget.getLineAtOffset(currentOffset);
                 int lineIdx = expandedCurrentOffset - startLineOffset;
-                String contentInLine = widget.getLine(curLineInDoc) + widget.getLineDelimiter();
-                String currentRightCtx = "\n";
-                if (lineIdx < contentInLine.length()) {
-                    currentRightCtx = contentInLine.substring(lineIdx);
-                }
+                String contentInLine = widget.getLine(curLineInDoc);
+                String currentRightCtx = contentInLine.substring(lineIdx);
                 int distanceToNewLine = currentRightCtx.length();
                 doc.replace(expandedCurrentOffset, distanceToNewLine, toAppend);
             } catch (BadLocationException e) {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QInvocationSession.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QInvocationSession.java
@@ -521,7 +521,6 @@ public final class QInvocationSession extends QResource {
         if (terminationListener != null) {
             widget.removeFocusListener(terminationListener);
         }
-        QInvocationSession.getInstance().getViewer().getTextWidget().redraw();
         if (paintListener != null) {
             paintListener.beforeRemoval();
             widget.removePaintListener(paintListener);
@@ -529,6 +528,12 @@ public final class QInvocationSession extends QResource {
         if (caretListener != null) {
             widget.removeCaretListener(caretListener);
         }
+        Display.getDefault().asyncExec(() -> {
+            if (!widget.isDisposed()) {
+                widget.redraw();
+                widget.update();
+            }
+        });
         paintListener = null;
         caretListener = null;
         inputListener = null;


### PR DESCRIPTION
*Issue #, if available:*

*Context*:
- When an inline session is invoked in the middle of a line _and_ whose suggestion returned as multiple lines (i.e. the suggestion contains line break), the right context on the invocation line is always discarded by the lsp server. 
- This intent to discard said right context under the aforementioned condition is denoted visually by a strike through. 
- During the preview, said right context is deleted from the user buffer in the editor, but stored in memory.
- Should user decides to accept the suggestion, said right context would be deleted permanently.
- If preview is terminated without acceptance, said right context would once again be appended.

*Description of changes:*
- Simplifies the logic to capture right context on the same line when starting a typeahead session
- Accordingly simplifies the logic to "return" the right context when said session ends
- Calls redraw on widget in a display thread after having checked for dispose status for safety 

*Test*:
On mac: 
- Deleting past inline invocation offset does not cause the subsequent lines to be edited
![macos_deletion](https://github.com/user-attachments/assets/f4c4ef7a-65de-48bd-a9f5-c2b2d29ba0a1)

On windows:
- Deleting past inline invocation offset does not cause the subsequent lines to be edited
![windows_deletion](https://github.com/user-attachments/assets/b420f381-3b4e-459d-b132-b3f5b271b38c)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
