### PR TITLE
Add plugin preference pane support for proxy config

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/LspStartupActivity.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/LspStartupActivity.java
@@ -3,10 +3,6 @@
 
 package software.aws.toolkits.eclipse.amazonq.lsp;
 
-import org.eclipse.core.net.proxy.IProxyChangeEvent;
-import org.eclipse.core.net.proxy.IProxyChangeListener;
-import org.eclipse.core.net.proxy.IProxyData;
-import org.eclipse.core.net.proxy.IProxyService;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -27,7 +23,6 @@ import software.aws.toolkits.eclipse.amazonq.util.AutoTriggerTopLevelListener;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
 import software.aws.toolkits.eclipse.amazonq.telemetry.ToolkitTelemetryProvider;
 import software.aws.toolkits.eclipse.amazonq.telemetry.metadata.ExceptionMetadata;
-import software.aws.toolkits.eclipse.amazonq.util.ProxyUtil;
 import software.aws.toolkits.eclipse.amazonq.views.ViewConstants;
 import software.aws.toolkits.eclipse.amazonq.util.ToolkitNotification;
 import org.eclipse.mylyn.commons.ui.dialogs.AbstractNotificationPopup;
@@ -38,29 +33,6 @@ import org.eclipse.lsp4e.LanguageServersRegistry;
 
 @SuppressWarnings("restriction")
 public class LspStartupActivity implements IStartup {
-
-    private void checkProxyConfiguration() {
-        ProxyUtil.updateHttpsProxyUrl("");
-        IProxyService proxyService = PlatformUI.getWorkbench().getService(IProxyService.class);
-        if (proxyService != null && proxyService.isProxiesEnabled()) {
-            IProxyData proxyData = proxyService.getProxyData(IProxyData.HTTPS_PROXY_TYPE);
-            if (ProxyUtil.isProxyValid(proxyData)) {
-                ProxyUtil.updateHttpsProxyUrl(ProxyUtil.createHttpsProxyHost(proxyData));
-            }
-        }
-        proxyService.addProxyChangeListener(new IProxyChangeListener() {
-            @Override
-            public void proxyInfoChanged(final IProxyChangeEvent event) {
-                ProxyUtil.updateHttpsProxyUrl("");
-                Display.getCurrent().asyncExec(() -> {
-                    AbstractNotificationPopup notification = new ToolkitNotification(Display.getCurrent(),
-                            Constants.PROXY_UPDATE_NOTIFICATION_TITLE,
-                            Constants.PROXY_UPDATE_NOTIFICATION_DESCRIPTION);
-                    notification.open();
-                });
-            }
-        });
-    }
 
     @Override
     public final void earlyStartup() {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/auth/DefaultLoginService.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/auth/DefaultLoginService.java
@@ -19,7 +19,6 @@ import software.aws.toolkits.eclipse.amazonq.lsp.encryption.DefaultLspEncryption
 import software.aws.toolkits.eclipse.amazonq.lsp.encryption.LspEncryptionManager;
 import software.aws.toolkits.eclipse.amazonq.providers.LspProvider;
 import software.aws.toolkits.eclipse.amazonq.util.AuthUtil;
-import software.aws.toolkits.eclipse.amazonq.util.ThreadingUtils;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
 
 /**
@@ -167,7 +166,7 @@ public final class DefaultLoginService implements LoginService {
                 .thenRun(() -> {
                   authStateManager.toLoggedIn(loginType, loginParams, ssoTokenId.get());
                   Activator.getLogger().info("Successfully logged in");
-                  ThreadingUtils.executeAsyncTask(() -> CustomizationUtil.triggerChangeConfigurationNotification());
+                  CustomizationUtil.triggerChangeConfigurationNotification();
               })
               .exceptionally(throwable -> {
                   throw new AmazonQPluginException("Failed to process log in", throwable);

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProvider.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import software.amazon.awssdk.utils.StringUtils;
 import software.aws.toolkits.eclipse.amazonq.lsp.encryption.DefaultLspEncryptionManager;
 import software.aws.toolkits.eclipse.amazonq.lsp.manager.LspManager;
 import software.aws.toolkits.eclipse.amazonq.lsp.manager.fetcher.RecordLspSetupArgs;
@@ -19,6 +20,7 @@ import software.aws.toolkits.eclipse.amazonq.telemetry.LanguageServerTelemetryPr
 import software.aws.toolkits.eclipse.amazonq.telemetry.metadata.ExceptionMetadata;
 import software.aws.toolkits.telemetry.TelemetryDefinitions.Result;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
+import software.aws.toolkits.eclipse.amazonq.preferences.AmazonQPreferencePage;
 
 public class QLspConnectionProvider extends AbstractLspConnectionProvider {
 
@@ -41,6 +43,14 @@ public class QLspConnectionProvider extends AbstractLspConnectionProvider {
 
     @Override
     protected final void addEnvironmentVariables(final Map<String, String> env) {
+        String httpsProxyPreference = Activator.getDefault().getPreferenceStore().getString(AmazonQPreferencePage.HTTPS_PROXY);
+        String caCertPreference = Activator.getDefault().getPreferenceStore().getString(AmazonQPreferencePage.CA_CERT);
+        if (!StringUtils.isEmpty(caCertPreference)) {
+            env.put("HTTPS_PROXY", httpsProxyPreference);
+        }
+        if (!StringUtils.isEmpty(caCertPreference)) {
+            env.put("NODE_EXTRA_CA_CERTS", caCertPreference);
+        }
         env.put("ENABLE_INLINE_COMPLETION", "true");
         env.put("ENABLE_TOKEN_PROVIDER", "true");
     }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/preferences/AmazonQPreferenceInitializer.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/preferences/AmazonQPreferenceInitializer.java
@@ -20,6 +20,8 @@ public class AmazonQPreferenceInitializer extends AbstractPreferenceInitializer 
         store.setDefault(AmazonQPreferencePage.CODE_REFERENCE_OPT_IN, true);
         store.setDefault(AmazonQPreferencePage.TELEMETRY_OPT_IN, true);
         store.setDefault(AmazonQPreferencePage.Q_DATA_SHARING, true);
+        store.setDefault(AmazonQPreferencePage.HTTPS_PROXY, "");
+        store.setDefault(AmazonQPreferencePage.CA_CERT, "");
         store.addPropertyChangeListener(event -> {
             ThreadingUtils.executeAsyncTask(() -> {
                 Activator.getLspProvider().getAmazonQServer()

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/preferences/AmazonQPreferencePage.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/preferences/AmazonQPreferencePage.java
@@ -4,8 +4,10 @@
 package software.aws.toolkits.eclipse.amazonq.preferences;
 
 import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.FileFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -30,6 +32,8 @@ public class AmazonQPreferencePage extends FieldEditorPreferencePage implements 
     public static final String CODE_REFERENCE_OPT_IN = "codeReferenceOptIn";
     public static final String TELEMETRY_OPT_IN = "telemetryOptIn";
     public static final String Q_DATA_SHARING = "qDataSharing";
+    public static final String HTTPS_PROXY = "httpsProxy";
+    public static final String CA_CERT = "customCaCert";
 
     private Boolean isTelemetryOptInChecked;
     private Boolean isQDataSharingOptInChecked;
@@ -55,6 +59,8 @@ public class AmazonQPreferencePage extends FieldEditorPreferencePage implements 
 
     @Override
     protected final void createFieldEditors() {
+        ((GridLayout) getFieldEditorParent().getLayout()).numColumns = 1;
+
         createHorizontalSeparator();
         createHeading("Inline Suggestions");
         createCodeReferenceOptInField();
@@ -62,7 +68,9 @@ public class AmazonQPreferencePage extends FieldEditorPreferencePage implements 
         createTelemetryOptInField();
         createHorizontalSeparator();
         createQDataSharingField();
-        adjustGridLayout();
+        createHeading("Proxy Settings");
+        createHttpsProxyField();
+        createCaCertField();
 
         GetConfigurationFromServerParams params = new GetConfigurationFromServerParams();
         params.setSection("aws.q");
@@ -174,6 +182,41 @@ public class AmazonQPreferencePage extends FieldEditorPreferencePage implements 
         });
     }
 
+    private void createHttpsProxyField() {
+        Composite httpsProxyComposite = new Composite(getFieldEditorParent(), SWT.NONE);
+        httpsProxyComposite.setLayout(new GridLayout(2, false));
+        GridData httpsProxyCompositeData = new GridData(SWT.LEFT, SWT.CENTER, true, false);
+        httpsProxyCompositeData.horizontalIndent = 20;
+        httpsProxyComposite.setLayoutData(httpsProxyCompositeData);
+        StringFieldEditor httpsProxy = new StringFieldEditor(HTTPS_PROXY, "HTTPS Proxy URL", 65, httpsProxyComposite);
+        httpsProxy.setEmptyStringAllowed(true);
+        addField(httpsProxy);
+        createLabel("""
+                Sets the address of the proxy to use for all HTTPS connections. \
+                Leave blank if not using a proxy.
+                Eclipse restart required to take effect.
+                """, 20, getFieldEditorParent());
+    }
+
+    private void createCaCertField() {
+        Composite caCertComposite = new Composite(getFieldEditorParent(), SWT.NONE);
+        caCertComposite.setLayout(new GridLayout(2, false));
+        GridData caCertCompositeData = new GridData(SWT.LEFT, SWT.CENTER, true, false);
+        caCertCompositeData.horizontalIndent = 20;
+        caCertCompositeData.widthHint = 715;
+        caCertComposite.setLayoutData(caCertCompositeData);
+
+        FileFieldEditor caCert = new FileFieldEditor(CA_CERT, "CA Cert PEM", true, StringFieldEditor.VALIDATE_ON_KEY_STROKE, caCertComposite);
+        caCert.setFileExtensions(new String[] {"*.pem"});
+        caCert.setErrorMessage("CA cert must be an existing PEM file");
+        addField(caCert);
+        createLabel("""
+                Absolute path to file containing extra certificates to extend beyond the root CAs. \
+                Leave blank for default CA certs.
+                Eclipse restart required to take effect.
+                """, 20, getFieldEditorParent());
+    }
+
     private Link createLink(final String text, final int horizontalIndent, final Composite parent) {
         Link link = new Link(parent, SWT.NONE);
         link.setText(text);
@@ -181,6 +224,15 @@ public class AmazonQPreferencePage extends FieldEditorPreferencePage implements 
         linkData.horizontalIndent = horizontalIndent;
         link.setLayoutData(linkData);
         return link;
+    }
+
+    private Label createLabel(final String text, final int horizontalIndent, final Composite parent) {
+        Label label = new Label(parent, SWT.HORIZONTAL);
+        label.setText(text);
+        GridData labelData = new GridData(SWT.FILL, SWT.CENTER, true, false);
+        labelData.horizontalIndent = horizontalIndent;
+        label.setLayoutData(labelData);
+        return label;
     }
 
     @Override
@@ -212,6 +264,11 @@ public class AmazonQPreferencePage extends FieldEditorPreferencePage implements 
                     changedDataSharingOptInChecked.toString());
             isQDataSharingOptInChecked = changedDataSharingOptInChecked;
         }
+    }
+
+    @Override
+    protected void adjustGridLayout() {
+        // deliberately left blank to prevent multiple columns from implicitly being created
     }
 
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/telemetry/service/DefaultTelemetryService.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/telemetry/service/DefaultTelemetryService.java
@@ -141,7 +141,7 @@ public final class DefaultTelemetryService implements TelemetryService {
             null,
             SSLConnectionSocketFactory.getDefaultHostnameVerifier()
         );
-        var proxyUrl = ProxyUtil.getHttpsProxyUrlEnvVar();
+        var proxyUrl = ProxyUtil.getHttpsProxyUrl();
         var httpClientBuilder = ApacheHttpClient.builder();
         if (!StringUtils.isEmpty(proxyUrl)) {
             httpClientBuilder.proxyConfiguration(ProxyConfiguration.builder()

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
@@ -34,4 +34,7 @@ public final class Constants {
             + " of the IDE preferences.";
     public static final String RE_AUTHENTICATE_FAILURE_MESSAGE = "An error occurred while attempting to re-authenticate. Please try again.";
     public static final String AUTHENTICATE_FAILURE_MESSAGE = "An error occurred while attempting to authenticate. Please try again.";
+    public static final String IDE_SSL_HANDSHAKE_TITLE = "SSL Handshake Error";
+    public static final String IDE_SSL_HANDSHAKE_BODY = "The plugin encountered an SSL handshake error. If using a proxy, check the plugin preferences.";
+
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/HttpClientFactory.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/HttpClientFactory.java
@@ -28,7 +28,7 @@ public final class HttpClientFactory {
             synchronized (HttpClientFactory.class) {
                 if (instance == null) {
                     var builder = HttpClient.newBuilder();
-                    var proxyUrl = ProxyUtil.getHttpsProxyUrlEnvVar();
+                    var proxyUrl = ProxyUtil.getHttpsProxyUrl();
                     if (!StringUtils.isEmpty(proxyUrl)) {
                         InetSocketAddress proxyAddress = getProxyAddress(proxyUrl);
                         builder.proxy(ProxySelector.of(proxyAddress));

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/ProxyUtil.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/ProxyUtil.java
@@ -10,7 +10,6 @@ import java.security.cert.X509Certificate;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
-import org.eclipse.core.net.proxy.IProxyData;
 import software.amazon.awssdk.utils.StringUtils;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
 import software.aws.toolkits.eclipse.amazonq.preferences.AmazonQPreferencePage;
@@ -21,51 +20,17 @@ public final class ProxyUtil {
         // Prevent initialization
     }
 
-    private static String proxyHttpsUrl = "";
-
     public static String getHttpsProxyUrl() {
-        return proxyHttpsUrl;
+        return getHttpsProxyUrl(System.getenv("HTTPS_PROXY"),
+                Activator.getDefault().getPreferenceStore().getString(AmazonQPreferencePage.HTTPS_PROXY));
     }
 
-    public static String getHttpsProxyUrlEnvVar() {
-        String httpsProxy = System.getenv("HTTPS_PROXY");
-        String httpsProxyPreference = Activator.getDefault().getPreferenceStore().getString(AmazonQPreferencePage.HTTPS_PROXY);
-        if (!StringUtils.isEmpty(httpsProxyPreference)) {
-            httpsProxy = httpsProxyPreference;
+    protected static String getHttpsProxyUrl(final String envVarValue, final String prefValue) {
+        String httpsProxy = envVarValue;
+        if (!StringUtils.isEmpty(prefValue)) {
+            httpsProxy = prefValue;
         }
         return httpsProxy;
-    }
-
-    public static void updateHttpsProxyUrl(final String proxyHost) {
-        proxyHttpsUrl = proxyHost;
-    }
-
-    public static boolean isProxyValid(final IProxyData proxyData) {
-        if (proxyData == null) {
-            return false;
-        }
-        String host = proxyData.getHost();
-        int port = proxyData.getPort();
-        String user = proxyData.getUserId();
-        String password = proxyData.getPassword();
-        return (
-            (!StringUtils.isEmpty(host) && port != -1 && !StringUtils.isEmpty(user) && !StringUtils.isEmpty(password))
-            || (!StringUtils.isEmpty(host) && port != -1)
-        );
-    }
-
-    public static String createHttpsProxyHost(final IProxyData proxyData) {
-        String host = proxyData.getHost();
-        int port = proxyData.getPort();
-        String user = proxyData.getUserId();
-        String password = proxyData.getPassword();
-        String proxiedHost = "";
-        if (!StringUtils.isEmpty(host) && port != -1 && !StringUtils.isEmpty(user) && !StringUtils.isEmpty(password)) {
-            return "http://" + user + ":" + password + "@" + host + ":" + Integer.toString(port);
-        } else if (!StringUtils.isEmpty(host) && port != -1) {
-            return "https://" + host + ":" + Integer.toString(port);
-        }
-        return proxiedHost;
     }
 
     public static SSLContext getCustomSslContext() {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/ProxyUtil.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/ProxyUtil.java
@@ -13,6 +13,7 @@ import javax.net.ssl.TrustManagerFactory;
 import org.eclipse.core.net.proxy.IProxyData;
 import software.amazon.awssdk.utils.StringUtils;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
+import software.aws.toolkits.eclipse.amazonq.preferences.AmazonQPreferencePage;
 
 public final class ProxyUtil {
 
@@ -27,7 +28,12 @@ public final class ProxyUtil {
     }
 
     public static String getHttpsProxyUrlEnvVar() {
-        return System.getenv("HTTPS_PROXY");
+        String httpsProxy = System.getenv("HTTPS_PROXY");
+        String httpsProxyPreference = Activator.getDefault().getPreferenceStore().getString(AmazonQPreferencePage.HTTPS_PROXY);
+        if (!StringUtils.isEmpty(httpsProxyPreference)) {
+            httpsProxy = httpsProxyPreference;
+        }
+        return httpsProxy;
     }
 
     public static void updateHttpsProxyUrl(final String proxyHost) {
@@ -65,6 +71,11 @@ public final class ProxyUtil {
     public static SSLContext getCustomSslContext() {
         try {
             String customCertPath = System.getenv("NODE_EXTRA_CA_CERTS");
+            String caCertPreference = Activator.getDefault().getPreferenceStore().getString(AmazonQPreferencePage.CA_CERT);
+            if (!StringUtils.isEmpty(caCertPreference)) {
+                customCertPath = caCertPreference;
+            }
+
             if (customCertPath != null && !customCertPath.isEmpty()) {
                 CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
                 X509Certificate cert;

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/extensions/implementation/ActivatorStaticMockExtension.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/extensions/implementation/ActivatorStaticMockExtension.java
@@ -4,9 +4,11 @@
 package software.aws.toolkits.eclipse.amazonq.extensions.implementation;
 
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 import java.util.Map;
 
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -42,6 +44,9 @@ public final class ActivatorStaticMockExtension extends StaticMockExtension<Acti
         LoginService loginServiceMock = Mockito.mock(LoginService.class);
         PluginStore pluginStoreMock = Mockito.mock(PluginStore.class);
         CodeReferenceLoggingService codeReferenceLoggingServiceMock = Mockito.mock(CodeReferenceLoggingService.class);
+
+        IPreferenceStore mockPreferenceStore = Mockito.mock(IPreferenceStore.class);
+        when(activatorMock.getPreferenceStore()).thenReturn(mockPreferenceStore);
 
         activatorStaticMock.when(Activator::getLogger).thenReturn(loggingServiceMock);
         activatorStaticMock.when(Activator::getTelemetryService).thenReturn(telemetryServiceMock);

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/lsp/auth/DefaultLoginServiceTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/lsp/auth/DefaultLoginServiceTest.java
@@ -69,6 +69,7 @@ public final class DefaultLoginServiceTest {
         mockedActivator = mockStatic(Activator.class);
         mockedActivator.when(Activator::getLogger).thenReturn(mockLoggingService);
         mockedAuthUtil = mockStatic(AuthUtil.class);
+        mockedActivator.when(Activator::getLspProvider).thenReturn(mockLspProvider);
 
         resetLoginService();
 

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/lsp/manager/fetcher/RemoteLspFetcherTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/lsp/manager/fetcher/RemoteLspFetcherTest.java
@@ -45,7 +45,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 
@@ -70,6 +69,7 @@ public final class RemoteLspFetcherTest {
     private LspFetcher lspFetcher;
     private Manifest sampleManifest;
     private final ArtifactVersion sampleLspVersion;
+    private HttpClient httpClient;
 
     @RegisterExtension
     private static ActivatorStaticMockExtension activatorStaticMockExtension = new ActivatorStaticMockExtension();
@@ -80,6 +80,7 @@ public final class RemoteLspFetcherTest {
     private RemoteLspFetcherTest() {
         sampleLspVersion = createLspVersion(sampleVersion);
         sampleManifest = createManifest(List.of(sampleLspVersion));
+        httpClient = mock(HttpClient.class);
         lspFetcher = createFetcher();
     }
 
@@ -88,9 +89,6 @@ public final class RemoteLspFetcherTest {
     private MockedStatic<LanguageServerTelemetryProvider> mockTelemetryProvider;
 
     private LoggingService mockLogger;
-
-    @Mock
-    private HttpClient httpClient;
 
     @TempDir(cleanup = CleanupMode.ALWAYS)
     private Path tempDir;

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/lsp/manager/fetcher/VersionManifestFetcherTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/lsp/manager/fetcher/VersionManifestFetcherTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -18,11 +19,13 @@ import java.nio.file.StandardCopyOption;
 
 import org.eclipse.core.internal.preferences.EclipsePreferences;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import software.aws.toolkits.eclipse.amazonq.configuration.DefaultPluginStore;
 import software.aws.toolkits.eclipse.amazonq.lsp.manager.LspConstants;
@@ -45,10 +48,15 @@ public final class VersionManifestFetcherTest {
     void setUp() {
         mockedLogger = mock(LoggingService.class);
         testPreferences = new EclipsePreferences();
+        Activator activatorMock = Mockito.mock(Activator.class);
+        IPreferenceStore mockPreferenceStore = Mockito.mock(IPreferenceStore.class);
+        when(activatorMock.getPreferenceStore()).thenReturn(mockPreferenceStore);
         mockedActivator = mockStatic(Activator.class);
         mockedActivator.when(Activator::getLogger).thenReturn(mockedLogger);
         mockedActivator.when(Activator::getPluginStore).thenReturn(new DefaultPluginStore(testPreferences));
+        mockedActivator.when(Activator::getDefault).thenReturn(activatorMock);
         mockTelemetryProvider = mockStatic(LanguageServerTelemetryProvider.class);
+
     }
 
     @AfterEach

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/util/ProxyUtilTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/util/ProxyUtilTest.java
@@ -5,61 +5,30 @@ package software.aws.toolkits.eclipse.amazonq.util;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import org.eclipse.core.net.proxy.IProxyData;
-import org.eclipse.core.internal.net.ProxyData;
 
 class ProxyUtilTest {
 
     @Test
-    void testIsValidProxySuccess() {
-        IProxyData httpsProxy = new ProxyData(IProxyData.HTTPS_PROXY_TYPE);
-        httpsProxy.setHost("127.0.0.1");
-        httpsProxy.setPort(8888);
-        assertEquals(true, ProxyUtil.isProxyValid(httpsProxy));
-
-        IProxyData httpsProxyWithAuth = new ProxyData(IProxyData.HTTPS_PROXY_TYPE);
-        httpsProxyWithAuth.setHost("127.0.0.1");
-        httpsProxyWithAuth.setPort(8888);
-        httpsProxyWithAuth.setUserid("user");
-        httpsProxyWithAuth.setPassword("password");
-        assertEquals(true, ProxyUtil.isProxyValid(httpsProxy));
+    void testNoProxyConfigReturnsNull() {
+        assertEquals(null, ProxyUtil.getHttpsProxyUrl(null, null));
     }
 
     @Test
-    void testIsValidProxyFailure() {
-        assertEquals(false, ProxyUtil.isProxyValid(null));
-
-        IProxyData httpsProxyWithNullHost = new ProxyData(IProxyData.HTTPS_PROXY_TYPE);
-        httpsProxyWithNullHost.setHost(null);
-        httpsProxyWithNullHost.setPort(8888);
-        assertEquals(false, ProxyUtil.isProxyValid(httpsProxyWithNullHost));
-
-        IProxyData httpsProxyWithInvalidPort = new ProxyData(IProxyData.HTTPS_PROXY_TYPE);
-        httpsProxyWithInvalidPort.setHost("127.0.0.1");
-        httpsProxyWithInvalidPort.setPort(-1);
-        assertEquals(false, ProxyUtil.isProxyValid(httpsProxyWithInvalidPort));
+    void testEnvVarProxyUrl() {
+        String mockUrl = "http://foo.com:8888";
+        assertEquals(mockUrl, ProxyUtil.getHttpsProxyUrl(mockUrl, null));
     }
 
     @Test
-    void testCreateHttpsProxyHost() {
-        IProxyData httpsProxy = new ProxyData(IProxyData.HTTPS_PROXY_TYPE);
-        httpsProxy.setHost("127.0.0.1");
-        httpsProxy.setPort(8888);
-        assertEquals("https://127.0.0.1:8888", ProxyUtil.createHttpsProxyHost(httpsProxy));
-
-        IProxyData httpsProxyWithAuth = new ProxyData(IProxyData.HTTPS_PROXY_TYPE);
-        httpsProxyWithAuth.setHost("127.0.0.1");
-        httpsProxyWithAuth.setPort(8888);
-        httpsProxyWithAuth.setUserid("user");
-        httpsProxyWithAuth.setPassword("password");
-        assertEquals("http://user:password@127.0.0.1:8888", ProxyUtil.createHttpsProxyHost(httpsProxyWithAuth));
+    void testPreferenceProxyUrl() {
+        String mockUrl = "http://foo.com:8888";
+        assertEquals(mockUrl, ProxyUtil.getHttpsProxyUrl(null, mockUrl));
     }
 
     @Test
-    void testUpdateAndGetProxyUrl() {
-        String initialState = ProxyUtil.getHttpsProxyUrl();
-        ProxyUtil.updateHttpsProxyUrl("https://127.0.0.1:8888");
-        assertEquals("https://127.0.0.1:8888", ProxyUtil.getHttpsProxyUrl());
-        ProxyUtil.updateHttpsProxyUrl(initialState);
+    void testPreferenceProxyUrlPrecedence() {
+        String mockUrl = "http://foo.com:8888";
+        assertEquals(mockUrl, ProxyUtil.getHttpsProxyUrl("http://bar.com:8888", mockUrl));
     }
+
 }


### PR DESCRIPTION
*Issue #, if available:*
Intended to address #286 - the difficulty of passing the appropriate proxy settings to the extension, which today can only be accomplished via environment variables.
 
*Description of changes:*
This change adds the ability to configure proxy settings (endpoint and CA cert file) within the extension's preferences pane.

![image](https://github.com/user-attachments/assets/a23dd0b3-cb7d-4fa9-9137-8f3347d7b52c)

Environment variables for these two settings will still be respected, but values set in the preference pane take priority. It is not feasible to use Eclipse's built in proxy settings since a trust store cannot be directly configured, and our underlying LSP process expects a CA cert.

This also adds detection for a case where an SSL exception is encountered and informs the user to check their configuration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
