### PR TITLE
Fix multi-window chat bug

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/handlers/QOpenLoginViewHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/handlers/QOpenLoginViewHandler.java
@@ -5,13 +5,22 @@ package software.aws.toolkits.eclipse.amazonq.handlers;
 
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
-import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
+import org.eclipse.ui.IViewPart;
+import org.eclipse.ui.IViewReference;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
 
+import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
+import software.aws.toolkits.eclipse.amazonq.views.AmazonQView;
 import software.aws.toolkits.eclipse.amazonq.views.ViewVisibilityManager;
 
 public class QOpenLoginViewHandler extends AbstractHandler {
+
     @Override
     public final Object execute(final ExecutionEvent event) {
+        closeAnyOpenQViews();
+
         if (Activator.getLoginService().getAuthState().isLoggedIn()) {
             ViewVisibilityManager.showChatView("statusBar");
         } else {
@@ -19,4 +28,30 @@ public class QOpenLoginViewHandler extends AbstractHandler {
         }
         return null;
     }
+
+    public final void closeAnyOpenQViews() {
+        IWorkbenchWindow activeWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+        IWorkbenchWindow[] windows = PlatformUI.getWorkbench().getWorkbenchWindows();
+
+        for (IWorkbenchWindow window : windows) {
+            IWorkbenchPage[] pages = window.getPages();
+
+            for (IWorkbenchPage page : pages) {
+                IViewReference[] viewReferences = page.getViewReferences();
+
+                for (IViewReference viewRef : viewReferences) {
+                    IViewPart view = viewRef.getView(false);
+
+                    if (view instanceof AmazonQView) {
+                        page.hideView(view);
+                    }
+                }
+            }
+        }
+
+        if (activeWindow != null) {
+            activeWindow.getShell().setActive();
+        }
+    }
+
 }


### PR DESCRIPTION
Issue #300 

*Description of changes:*
This PR implements a fix to improve the behavior of Amazon Q views across multiple windows in the IDE.
- Added a check for to find existing Amazon Q views in any window within the IDE before launching a new Amazon Q view.
- Implemented logic to close of any such existing Amazon Q views before launching the new one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
