### PR TITLE
Fix status bar alignment issue on macOS and hide on log out

### DIFF
--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -422,6 +422,11 @@
                 class="software.aws.toolkits.eclipse.amazonq.views.actions.InlineQueryStatusBarContribution"
                 id="software.aws.toolkits.eclipse.amazonq.views.actions.InlineQueryStatusBarContribution"
                 >
+                <visibleWhen checkEnabled="false">
+                    <with variable="is_logged_in">
+                        <equals value="true"/>
+                    </with>
+                </visibleWhen>
                 </control>
            </toolbar>
         </menuContribution>

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/InlineQueryStatusBarContribution.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/InlineQueryStatusBarContribution.java
@@ -4,6 +4,8 @@
 package software.aws.toolkits.eclipse.amazonq.views.actions;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
@@ -25,7 +27,20 @@ public final class InlineQueryStatusBarContribution extends WorkbenchWindowContr
 
     @Override
     protected Control createControl(final Composite parent) {
+        GridData parentData = new GridData(SWT.FILL, SWT.FILL, true, false);
+        parentData.verticalIndent = 0;
+        parent.setLayoutData(parentData);
+
+        GridLayout layout = new GridLayout();
+        layout.marginHeight = 0;
+        layout.marginLeft = 1;
+        layout.marginRight = 1;
+        layout.horizontalSpacing = 0;
+        layout.verticalSpacing = 0;
+        parent.setLayout(layout);
+
         statusLabel = new Label(parent, SWT.NONE);
+        statusLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, true));
         statusLabel.setText(IDLE_STATUS);
         QInvocationSession session = QInvocationSession.getInstance();
         session.assignQueryingCallback(new Runnable() {


### PR DESCRIPTION
*Description of changes:*
This change adds logic to only show the status bar given a logged in state. Also fixes misalignment issue of the status bar on macOS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
