### PR TITLE
Adds check to prevent auto trigger from firing when user is logged out

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/AutoTriggerDocumentListener.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/AutoTriggerDocumentListener.java
@@ -9,6 +9,8 @@ import org.eclipse.jface.text.IDocumentListener;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
 
+import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
+
 import static software.aws.toolkits.eclipse.amazonq.util.QEclipseEditorUtils.getActiveTextEditor;
 
 import java.util.concurrent.ExecutionException;
@@ -45,6 +47,10 @@ public final class AutoTriggerDocumentListener implements IDocumentListener, IAu
     }
 
     private boolean shouldSendQuery(final DocumentEvent e, final QInvocationSession session) {
+        if (!Activator.getLoginService().getAuthState().isLoggedIn()) {
+            return false;
+        }
+
         if (e.getText().length() <= 0) {
             return false;
         }

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/util/AutoTriggerDocumentListenerTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/util/AutoTriggerDocumentListenerTest.java
@@ -27,12 +27,15 @@ import org.mockito.MockedStatic;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
+
 public class AutoTriggerDocumentListenerTest {
     private static final String TEXT_STUB = "some stuff";
 
     private static MockedStatic<QInvocationSession> sessionMockStatic;
     private static MockedStatic<QEclipseEditorUtils> editorUtilsMockStatic;
     private static MockedStatic<PlatformUI> platformUIMockStatic;
+    private static MockedStatic<Activator> activatorMockStatic;
 
     private static QInvocationSession sessionMock;
     private static IExecutionListener executionListenerMock;
@@ -51,6 +54,9 @@ public class AutoTriggerDocumentListenerTest {
         ICommandService commandServiceMock = mock(ICommandService.class);
         platformUIMockStatic.when(() -> PlatformUI.getWorkbench().getService(ICommandService.class))
                 .thenReturn(commandServiceMock);
+
+        activatorMockStatic = mockStatic(Activator.class, RETURNS_DEEP_STUBS);
+        activatorMockStatic.when(() -> Activator.getLoginService().getAuthState().isLoggedIn()).thenReturn(true);
     }
 
     @AfterAll
@@ -58,6 +64,7 @@ public class AutoTriggerDocumentListenerTest {
         sessionMockStatic.close();
         editorUtilsMockStatic.close();
         platformUIMockStatic.close();
+        activatorMockStatic.close();
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- This is a hot fix to patch auto trigger from being made when user is logged out.
- Adds a check in the auto trigger logic to determine if user is logged in. Queries will only be made if the user is logged in. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
