### PR TITLE
improved handling of lsp failure state

### DIFF
--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -28,7 +28,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.31.0",
  org.apache.commons.logging;bundle-version="1.2.0",
  slf4j.api;bundle-version="2.0.13",
  org.apache.commons.lang3;bundle-version="3.14.0"
-Bundle-Classpath: .,
+Bundle-Classpath: target/classes/,
  target/dependency/annotations-2.28.26.jar,
  target/dependency/apache-client-2.28.26.jar,
  target/dependency/auth-2.28.26.jar,

--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -28,7 +28,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.31.0",
  org.apache.commons.logging;bundle-version="1.2.0",
  slf4j.api;bundle-version="2.0.13",
  org.apache.commons.lang3;bundle-version="3.14.0"
-Bundle-Classpath: target/classes/,
+Bundle-Classpath: .,
  target/dependency/annotations-2.28.26.jar,
  target/dependency/apache-client-2.28.26.jar,
  target/dependency/auth-2.28.26.jar,

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -34,6 +34,12 @@
             class="software.aws.toolkits.eclipse.amazonq.views.ChatAssetMissingView">
         </view>
         <view
+            id="software.aws.toolkits.eclipse.amazonq.views.LspStartUpFailedView"
+            name="Amazon Q"
+            icon="icons/AmazonQ.png"
+            class="software.aws.toolkits.eclipse.amazonq.views.LspStartUpFailedView">
+        </view>
+        <view
             id="software.aws.toolkits.eclipse.amazonq.views.ToolkitLoginWebview"
             name="Amazon Q"
             icon="icons/AmazonQ.png"
@@ -138,6 +144,12 @@
             </view>
              <view
                 id="software.aws.toolkits.eclipse.amazonq.views.ChatAssetMissingView"
+                relative="software.aws.toolkits.eclipse.amazonq.views.ToolkitLoginWebview"
+                relationship="stack"
+                visible="false">
+            </view>
+            <view
+                id="software.aws.toolkits.eclipse.amazonq.views.LspStartUpFailedView"
                 relative="software.aws.toolkits.eclipse.amazonq.views.ToolkitLoginWebview"
                 relationship="stack"
                 visible="false">

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/handlers/AbstractQChatEditorActionsHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/handlers/AbstractQChatEditorActionsHandler.java
@@ -15,6 +15,7 @@ import software.aws.toolkits.eclipse.amazonq.chat.models.ChatUIInboundCommand;
 import software.aws.toolkits.eclipse.amazonq.chat.models.GenericCommandParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.SendToPromptParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.TriggerType;
+import software.aws.toolkits.eclipse.amazonq.lsp.manager.LspStatusManager;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
 import software.aws.toolkits.eclipse.amazonq.telemetry.ToolkitTelemetryProvider;
 import software.aws.toolkits.eclipse.amazonq.telemetry.metadata.ExceptionMetadata;
@@ -27,7 +28,7 @@ public abstract class AbstractQChatEditorActionsHandler extends AbstractHandler 
     @Override
     public final boolean isEnabled() {
         try {
-            return Activator.getLoginService().getAuthState().isLoggedIn();
+            return Activator.getLoginService().getAuthState().isLoggedIn() && !LspStatusManager.lspFailed();
         } catch (Exception e) {
             return false;
         }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/handlers/AbstractQChatEditorActionsHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/handlers/AbstractQChatEditorActionsHandler.java
@@ -28,7 +28,7 @@ public abstract class AbstractQChatEditorActionsHandler extends AbstractHandler 
     @Override
     public final boolean isEnabled() {
         try {
-            return Activator.getLoginService().getAuthState().isLoggedIn() && !LspStatusManager.lspFailed();
+            return Activator.getLoginService().getAuthState().isLoggedIn() && !LspStatusManager.getInstance().lspFailed();
         } catch (Exception e) {
             return false;
         }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/handlers/QOpenLoginViewHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/handlers/QOpenLoginViewHandler.java
@@ -7,13 +7,12 @@ import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 
 import software.aws.toolkits.eclipse.amazonq.lsp.manager.LspStatusManager;
-
 import software.aws.toolkits.eclipse.amazonq.views.ViewVisibilityManager;
 
 public class QOpenLoginViewHandler extends AbstractHandler {
     @Override
     public final Object execute(final ExecutionEvent event) {
-        if (LspStatusManager.lspFailed()) {
+        if (LspStatusManager.getInstance().lspFailed()) {
             ViewVisibilityManager.showLspStartUpFailedView("statusBar");
         } else {
             ViewVisibilityManager.showDefaultView("statusBar");

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/handlers/QOpenLoginViewHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/handlers/QOpenLoginViewHandler.java
@@ -5,17 +5,18 @@ package software.aws.toolkits.eclipse.amazonq.handlers;
 
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
-import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
+
+import software.aws.toolkits.eclipse.amazonq.lsp.manager.LspStatusManager;
 
 import software.aws.toolkits.eclipse.amazonq.views.ViewVisibilityManager;
 
 public class QOpenLoginViewHandler extends AbstractHandler {
     @Override
     public final Object execute(final ExecutionEvent event) {
-        if (Activator.getLoginService().getAuthState().isLoggedIn()) {
-            ViewVisibilityManager.showChatView("statusBar");
+        if (LspStatusManager.lspFailed()) {
+            ViewVisibilityManager.showLspStartUpFailedView("statusBar");
         } else {
-            ViewVisibilityManager.showLoginView("statusBar");
+            ViewVisibilityManager.showDefaultView("statusBar");
         }
         return null;
     }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProvider.java
@@ -16,13 +16,13 @@ import software.aws.toolkits.eclipse.amazonq.lsp.encryption.DefaultLspEncryption
 import software.aws.toolkits.eclipse.amazonq.lsp.manager.LspManager;
 import software.aws.toolkits.eclipse.amazonq.lsp.manager.LspStatusManager;
 import software.aws.toolkits.eclipse.amazonq.lsp.manager.fetcher.RecordLspSetupArgs;
+import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
+import software.aws.toolkits.eclipse.amazonq.preferences.AmazonQPreferencePage;
 import software.aws.toolkits.eclipse.amazonq.providers.LspManagerProvider;
 import software.aws.toolkits.eclipse.amazonq.telemetry.LanguageServerTelemetryProvider;
 import software.aws.toolkits.eclipse.amazonq.telemetry.metadata.ExceptionMetadata;
 import software.aws.toolkits.eclipse.amazonq.util.ProxyUtil;
 import software.aws.toolkits.telemetry.TelemetryDefinitions.Result;
-import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
-import software.aws.toolkits.eclipse.amazonq.preferences.AmazonQPreferencePage;
 
 public class QLspConnectionProvider extends AbstractLspConnectionProvider {
 
@@ -43,7 +43,7 @@ public class QLspConnectionProvider extends AbstractLspConnectionProvider {
             commands.add("--set-credentials-encryption-key");
             setCommands(commands);
         } catch (Exception e) {
-            LspStatusManager.setToFailed();
+            LspStatusManager.getInstance().setToFailed();
             throw(e);
         }
 
@@ -77,12 +77,12 @@ public class QLspConnectionProvider extends AbstractLspConnectionProvider {
 
                 lspEncryption.initializeEncryptedCommunication(serverStdIn);
             } catch (Exception e) {
-                LspStatusManager.setToFailed();
+                LspStatusManager.getInstance().setToFailed();
                 emitInitFailure(ExceptionMetadata.scrubException(e));
                 Activator.getLogger().error("Error occured while initializing communication with Amazon Q Lsp Server", e);
             }
         } catch (Exception e) {
-            LspStatusManager.setToFailed();
+            LspStatusManager.getInstance().setToFailed();
             emitInitFailure(ExceptionMetadata.scrubException(e));
             throw e;
         }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/LspState.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/LspState.java
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.lsp.manager;
+
+public enum LspState {
+    ACTIVE,
+    FAILED,
+    PENDING
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/LspStatusManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/LspStatusManager.java
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.lsp.manager;
+
+import software.aws.toolkits.eclipse.amazonq.views.ViewVisibilityManager;
+
+public final class LspStatusManager {
+
+    private LspStatusManager() {
+        //prevent
+    }
+
+    private static LspState lspState = LspState.PENDING;
+
+    public static boolean lspFailed() {
+        return (lspState == LspState.FAILED);
+    }
+    public static void setToActive() {
+        lspState = LspState.ACTIVE;
+        ViewVisibilityManager.showDefaultView("restart");
+    }
+    public static void setToFailed() {
+        if (lspState != LspState.FAILED) {
+            ViewVisibilityManager.showLspStartUpFailedView("update");
+            lspState = LspState.FAILED;
+        }
+    }
+    public static LspState getLspState() {
+        return lspState;
+    }
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/LspStatusManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/LspStatusManager.java
@@ -39,10 +39,10 @@ public final class LspStatusManager {
         if (lspState != LspState.FAILED) {
             ViewVisibilityManager.showLspStartUpFailedView("update");
             lspState = LspState.FAILED;
+            Activator.getEventBroker().post(lspState);
         }
-
-        Activator.getEventBroker().post(lspState);
     }
+
     public LspState getLspState() {
         return lspState;
     }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/LspStatusManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/LspStatusManager.java
@@ -8,7 +8,7 @@ import software.aws.toolkits.eclipse.amazonq.views.ViewVisibilityManager;
 public final class LspStatusManager {
 
     private LspStatusManager() {
-        //prevent
+        //prevent instantiation
     }
 
     private static LspState lspState = LspState.PENDING;

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/LspStatusManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/LspStatusManager.java
@@ -3,30 +3,47 @@
 
 package software.aws.toolkits.eclipse.amazonq.lsp.manager;
 
+import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
 import software.aws.toolkits.eclipse.amazonq.views.ViewVisibilityManager;
 
 public final class LspStatusManager {
 
-    private LspStatusManager() {
-        //prevent instantiation
+    private static final LspStatusManager INSTANCE;
+    private LspState lspState;
+
+    static {
+        INSTANCE = new LspStatusManager();
     }
 
-    private static LspState lspState = LspState.PENDING;
+    private LspStatusManager() {
+        lspState = LspState.PENDING;
+        Activator.getEventBroker().post(lspState);
+    }
 
-    public static boolean lspFailed() {
+    public static LspStatusManager getInstance() {
+        return INSTANCE;
+    }
+
+
+    public boolean lspFailed() {
         return (lspState == LspState.FAILED);
     }
-    public static void setToActive() {
+
+    public void setToActive() {
         lspState = LspState.ACTIVE;
+        Activator.getEventBroker().post(lspState);
         ViewVisibilityManager.showDefaultView("restart");
     }
-    public static void setToFailed() {
+
+    public void setToFailed() {
         if (lspState != LspState.FAILED) {
             ViewVisibilityManager.showLspStartUpFailedView("update");
             lspState = LspState.FAILED;
         }
+
+        Activator.getEventBroker().post(lspState);
     }
-    public static LspState getLspState() {
+    public LspState getLspState() {
         return lspState;
     }
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/LspProviderImpl.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/LspProviderImpl.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.lsp4j.services.LanguageServer;
 
 import software.aws.toolkits.eclipse.amazonq.lsp.AmazonQLspServer;
+import software.aws.toolkits.eclipse.amazonq.lsp.manager.LspStatusManager;
 import software.aws.toolkits.eclipse.amazonq.lsp.manager.fetcher.RecordLspSetupArgs;
 import software.aws.toolkits.eclipse.amazonq.telemetry.LanguageServerTelemetryProvider;
 import software.aws.toolkits.telemetry.TelemetryDefinitions.Result;
@@ -52,6 +53,7 @@ public final class LspProviderImpl implements LspProvider {
                 future.complete(server);
             }
             emitInitializeMetric();
+            LspStatusManager.setToActive();
         }
     }
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/LspProviderImpl.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/LspProviderImpl.java
@@ -53,7 +53,7 @@ public final class LspProviderImpl implements LspProvider {
                 future.complete(server);
             }
             emitInitializeMetric();
-            LspStatusManager.setToActive();
+            LspStatusManager.getInstance().setToActive();
         }
     }
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
@@ -21,6 +21,7 @@ import software.aws.toolkits.eclipse.amazonq.chat.ChatTheme;
 import software.aws.toolkits.eclipse.amazonq.configuration.PluginStoreKeys;
 import software.aws.toolkits.eclipse.amazonq.lsp.AwsServerCapabiltiesProvider;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.AuthState;
+import software.aws.toolkits.eclipse.amazonq.lsp.manager.LspStatusManager;
 import software.aws.toolkits.eclipse.amazonq.lsp.model.ChatOptions;
 import software.aws.toolkits.eclipse.amazonq.lsp.model.QuickActions;
 import software.aws.toolkits.eclipse.amazonq.lsp.model.QuickActionsCommandGroup;
@@ -141,7 +142,7 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
                 // chat view
                 if (browser != null && !browser.isDisposed() && !chatStateManager.hasPreservedState()) {
                     Optional<String> content = getContent();
-                    if (!content.isPresent()) {
+                    if (!content.isPresent() && !LspStatusManager.lspFailed()) {
                         canDisposeState = true;
                         ViewVisibilityManager.showChatAssetMissingView("update");
                     } else {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
@@ -142,7 +142,7 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
                 // chat view
                 if (browser != null && !browser.isDisposed() && !chatStateManager.hasPreservedState()) {
                     Optional<String> content = getContent();
-                    if (!content.isPresent() && !LspStatusManager.lspFailed()) {
+                    if (!content.isPresent() && !LspStatusManager.getInstance().lspFailed()) {
                         canDisposeState = true;
                         ViewVisibilityManager.showChatAssetMissingView("update");
                     } else {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
@@ -142,9 +142,11 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
                 // chat view
                 if (browser != null && !browser.isDisposed() && !chatStateManager.hasPreservedState()) {
                     Optional<String> content = getContent();
-                    if (!content.isPresent() && !LspStatusManager.getInstance().lspFailed()) {
+                    if (!content.isPresent()) {
                         canDisposeState = true;
-                        ViewVisibilityManager.showChatAssetMissingView("update");
+                        if (!LspStatusManager.getInstance().lspFailed()) {
+                            ViewVisibilityManager.showChatAssetMissingView("update");
+                        }
                     } else {
                         browser.setText(content.get()); // Display the chat client
                     }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/LspStartUpFailedView.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/LspStartUpFailedView.java
@@ -1,0 +1,44 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.views;
+import java.util.concurrent.CompletableFuture;
+
+import software.aws.toolkits.eclipse.amazonq.lsp.manager.LspStatusManager;
+
+public final class LspStartUpFailedView extends BaseView {
+    public static final String ID = "software.aws.toolkits.eclipse.amazonq.views.LspStartUpFailedView";
+
+    private static final String ICON_PATH = "icons/AmazonQ64.png";
+    private static final String HEADER_LABEL = "Language Server failed to start.";
+    private static final String DETAIL_MESSAGE = "Restart Eclipse or review error logs for troubleshooting";
+
+    /* TODO: After refactor of LSP error handling is completed,
+     * add logic to base detail_message on error code returned from exception
+     *  */
+    @Override
+    protected String getIconPath() {
+        return ICON_PATH;
+    }
+
+    @Override
+    protected String getHeaderLabel() {
+        return HEADER_LABEL;
+    }
+
+    @Override
+    protected String getDetailMessage() {
+        return DETAIL_MESSAGE;
+    }
+
+    @Override
+    protected void showAlternateView() {
+        ViewVisibilityManager.showDefaultView("restart");
+    }
+
+    @Override
+    protected CompletableFuture<Boolean> isViewDisplayable() {
+        return CompletableFuture.completedFuture(LspStatusManager.lspFailed());
+    }
+
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/LspStartUpFailedView.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/LspStartUpFailedView.java
@@ -38,7 +38,7 @@ public final class LspStartUpFailedView extends BaseView {
 
     @Override
     protected CompletableFuture<Boolean> isViewDisplayable() {
-        return CompletableFuture.completedFuture(LspStatusManager.lspFailed());
+        return CompletableFuture.completedFuture(LspStatusManager.getInstance().lspFailed());
     }
 
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/ViewVisibilityManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/ViewVisibilityManager.java
@@ -39,7 +39,10 @@ public final class ViewVisibilityManager {
     );
 
     public static void showDefaultView(final String source) {
-        if (Activator.getLoginService().getAuthState().isLoggedIn()) {
+        var authState = Activator.getLoginService().getAuthState();
+        if (authState.isExpired()) {
+            showReAuthView(source);
+        } else if (authState.isLoggedIn()) {
             showChatView(source);
         } else {
             showLoginView(source);

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/ViewVisibilityManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/ViewVisibilityManager.java
@@ -26,6 +26,7 @@ public final class ViewVisibilityManager {
     private static final String RE_AUTHENTICATE_VIEW = ReauthenticateView.ID;
     private static final String CHAT_ASSET_MISSING_VIEW = ChatAssetMissingView.ID;
     private static final String CODE_REFERENCE_VIEW = AmazonQCodeReferenceView.ID;
+    private static final String LSP_STARTUP_FAILED_VIEW = LspStartUpFailedView.ID;
     private static final String ERROR_LOG_VIEW = "org.eclipse.pde.runtime.LogView";
 
     private static final Set<String> MUTUALLY_EXCLUSIVE_VIEWS = Set.of(
@@ -33,8 +34,17 @@ public final class ViewVisibilityManager {
             CHAT_VIEW,
             DEPENDENCY_MISSING_VIEW,
             RE_AUTHENTICATE_VIEW,
-            CHAT_ASSET_MISSING_VIEW
+            CHAT_ASSET_MISSING_VIEW,
+            LSP_STARTUP_FAILED_VIEW
     );
+
+    public static void showDefaultView(final String source) {
+        if (Activator.getLoginService().getAuthState().isLoggedIn()) {
+            showChatView(source);
+        } else {
+            showLoginView(source);
+        }
+    }
 
     public static void showLoginView(final String source) {
         showMutuallyExclusiveView(TOOLKIT_LOGIN_VIEW, source);
@@ -54,6 +64,10 @@ public final class ViewVisibilityManager {
 
     public static void showChatAssetMissingView(final String source) {
         showMutuallyExclusiveView(CHAT_ASSET_MISSING_VIEW, source);
+    }
+
+    public static void showLspStartUpFailedView(final String source) {
+        showMutuallyExclusiveView(LSP_STARTUP_FAILED_VIEW, source);
     }
 
     public static void showCodeReferenceView(final String source) {

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProviderTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProviderTest.java
@@ -3,6 +3,24 @@
 
 package software.aws.toolkits.eclipse.amazonq.lsp.connection;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.lsp4e.server.ProcessStreamConnectionProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,26 +35,8 @@ import software.aws.toolkits.eclipse.amazonq.extensions.implementation.ProxyUtil
 import software.aws.toolkits.eclipse.amazonq.lsp.encryption.LspEncryptionManager;
 import software.aws.toolkits.eclipse.amazonq.lsp.manager.LspInstallResult;
 import software.aws.toolkits.eclipse.amazonq.lsp.manager.LspStatusManager;
-
-import org.eclipse.lsp4e.server.ProcessStreamConnectionProvider;
 import software.aws.toolkits.eclipse.amazonq.util.LoggingService;
 import software.aws.toolkits.eclipse.amazonq.util.ProxyUtil;
-
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.verify;
 
 public final class QLspConnectionProviderTest {
 
@@ -54,16 +54,19 @@ public final class QLspConnectionProviderTest {
     @RegisterExtension
     private static ProxyUtilsStaticMockExtension proxyUtilsStaticMockExtension = new ProxyUtilsStaticMockExtension();
 
-    private MockedStatic<LspStatusManager> mockLspStatusManager;
+    private MockedStatic<LspStatusManager> mockStaticLspStatusManager;
+    private LspStatusManager mockLspStatusManager;
 
     @BeforeEach
     void setupBeforeEach() {
-        mockLspStatusManager = mockStatic(LspStatusManager.class);
+        mockStaticLspStatusManager = mockStatic(LspStatusManager.class);
+        mockLspStatusManager = mock(LspStatusManager.class);
+        mockStaticLspStatusManager.when(LspStatusManager::getInstance).thenReturn(mockLspStatusManager);
     }
 
     @AfterEach
     void tearDown() {
-        mockLspStatusManager.close();
+        mockStaticLspStatusManager.close();
     }
 
     private static final class TestProcessConnectionProvider extends ProcessStreamConnectionProvider {
@@ -107,7 +110,7 @@ public final class QLspConnectionProviderTest {
                 "/test/dir"
         );
 
-        assertTrue(((ProcessStreamConnectionProvider) testProcessConnectionProvider).equals(provider));
+        assertTrue(testProcessConnectionProvider.equals(provider));
     }
 
     @Test

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProviderTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProviderTest.java
@@ -3,16 +3,21 @@
 
 package software.aws.toolkits.eclipse.amazonq.lsp.connection;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+
 import software.aws.toolkits.eclipse.amazonq.extensions.implementation.ActivatorStaticMockExtension;
 import software.aws.toolkits.eclipse.amazonq.extensions.implementation.DefaultLspEncryptionManagerStaticMockExtension;
 import software.aws.toolkits.eclipse.amazonq.extensions.implementation.LspManagerProviderStaticMockExtension;
 import software.aws.toolkits.eclipse.amazonq.extensions.implementation.ProxyUtilsStaticMockExtension;
 import software.aws.toolkits.eclipse.amazonq.lsp.encryption.LspEncryptionManager;
 import software.aws.toolkits.eclipse.amazonq.lsp.manager.LspInstallResult;
+import software.aws.toolkits.eclipse.amazonq.lsp.manager.LspStatusManager;
+
 import org.eclipse.lsp4e.server.ProcessStreamConnectionProvider;
 import software.aws.toolkits.eclipse.amazonq.util.LoggingService;
 import software.aws.toolkits.eclipse.amazonq.util.ProxyUtil;
@@ -30,6 +35,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 
 public final class QLspConnectionProviderTest {
@@ -47,6 +53,18 @@ public final class QLspConnectionProviderTest {
 
     @RegisterExtension
     private static ProxyUtilsStaticMockExtension proxyUtilsStaticMockExtension = new ProxyUtilsStaticMockExtension();
+
+    private MockedStatic<LspStatusManager> mockLspStatusManager;
+
+    @BeforeEach
+    void setupBeforeEach() {
+        mockLspStatusManager = mockStatic(LspStatusManager.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockLspStatusManager.close();
+    }
 
     private static final class TestProcessConnectionProvider extends ProcessStreamConnectionProvider {
 


### PR DESCRIPTION
[Issue #297](https://github.com/aws/amazon-q-eclipse/issues/297)

*Description of changes:*
Added enhancement to plugin in order to handle language server failure state gracefully, showing a view to the user and disabling interaction with certain features. 

Todo: While addressing exception handling in LSP components, we should consider conditionally adding detailed failure messages to this view based on error codes.

*Screenshot:*
![Screenshot 2024-12-20 at 11 03 37 AM](https://github.com/user-attachments/assets/4656ed14-2c03-44e4-82e9-7384a37f8d69)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
