### PR TITLE
Add UI notification to alert user of deprecated manifest version

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/DefaultLspManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/DefaultLspManager.java
@@ -261,7 +261,7 @@ public final class DefaultLspManager implements LspManager {
             Display.getDefault().asyncExec(() -> {
                 AbstractNotificationPopup notification = new PersistentToolkitNotification(Display.getCurrent(),
                         Constants.MANIFEST_DEPRECATED_NOTIFICATION_TITLE,
-                        Constants.MANIFEST_DEPRECATED_NOTIFICATION_BODY ,
+                        Constants.MANIFEST_DEPRECATED_NOTIFICATION_BODY,
                         (selected) -> {
                             if (selected) {
                                 Activator.getPluginStore().putObject(Constants.MANIFEST_DEPRECATED_NOTIFICATION_KEY, schemaVersion);

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/DefaultLspManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/DefaultLspManager.java
@@ -17,8 +17,8 @@ import java.util.Optional;
 import org.eclipse.swt.widgets.Display;
 import software.aws.toolkits.eclipse.amazonq.util.Constants;
 import software.aws.toolkits.eclipse.amazonq.util.PersistentToolkitNotification;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.eclipse.mylyn.commons.ui.dialogs.AbstractNotificationPopup;
-import org.osgi.framework.Version;
 
 import software.aws.toolkits.eclipse.amazonq.exception.AmazonQPluginException;
 import software.aws.toolkits.eclipse.amazonq.lsp.manager.fetcher.ArtifactUtils;
@@ -254,8 +254,10 @@ public final class DefaultLspManager implements LspManager {
     }
 
     private static void showDeprecatedManifestNotification(final String version) {
-        Version storedValue = Activator.getPluginStore().getObject(Constants.MANIFEST_DEPRECATED_NOTIFICATION_KEY, Version.class);
-        Version schemaVersion = ArtifactUtils.parseVersion(version);
+        ArtifactVersion schemaVersion = ArtifactUtils.parseVersion(version);
+        ArtifactVersion storedValue = Optional.ofNullable(Activator.getPluginStore().get(Constants.MANIFEST_DEPRECATED_NOTIFICATION_KEY))
+                .map(ArtifactUtils::parseVersion)
+                .orElse(null);
 
         if (storedValue == null || remoteVersionIsGreater(schemaVersion, storedValue)) {
             Display.getDefault().asyncExec(() -> {
@@ -264,7 +266,7 @@ public final class DefaultLspManager implements LspManager {
                         Constants.MANIFEST_DEPRECATED_NOTIFICATION_BODY,
                         (selected) -> {
                             if (selected) {
-                                Activator.getPluginStore().putObject(Constants.MANIFEST_DEPRECATED_NOTIFICATION_KEY, schemaVersion);
+                                Activator.getPluginStore().put(Constants.MANIFEST_DEPRECATED_NOTIFICATION_KEY, schemaVersion.toString());
                             } else {
                                 Activator.getPluginStore().remove(Constants.MANIFEST_DEPRECATED_NOTIFICATION_KEY);
                             }
@@ -274,7 +276,7 @@ public final class DefaultLspManager implements LspManager {
         }
     }
 
-    private static boolean remoteVersionIsGreater(final Version remote, final Version storedValue) {
+    private static boolean remoteVersionIsGreater(final ArtifactVersion remote, final ArtifactVersion storedValue) {
         return remote.compareTo(storedValue) > 0;
     }
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/DefaultLspManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/DefaultLspManager.java
@@ -14,6 +14,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Optional;
 
+import org.eclipse.swt.widgets.Display;
+import software.aws.toolkits.eclipse.amazonq.util.Constants;
+import software.aws.toolkits.eclipse.amazonq.util.ToolkitNotification;
+import org.eclipse.mylyn.commons.ui.dialogs.AbstractNotificationPopup;
+
 import software.aws.toolkits.eclipse.amazonq.exception.AmazonQPluginException;
 import software.aws.toolkits.eclipse.amazonq.lsp.manager.fetcher.ArtifactUtils;
 import software.aws.toolkits.eclipse.amazonq.lsp.manager.fetcher.LspFetcher;
@@ -82,6 +87,10 @@ public final class DefaultLspManager implements LspManager {
             return overrideResult;
         }
         Manifest manifest = fetchManifest();
+
+        if (manifest.isManifestDeprecated()) {
+            showDeprecatedManifestNotification();
+        }
 
         var platform = platformOverride != null ? platformOverride : PluginUtils.getPlatform();
         var architecture = architectureOverride != null ? architectureOverride : PluginUtils.getArchitecture();
@@ -237,6 +246,15 @@ public final class DefaultLspManager implements LspManager {
                 PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_EXECUTE,
                 PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE));
         Files.setPosixFilePermissions(filePath, permissions);
+    }
+    private static void showDeprecatedManifestNotification() {
+        Display.getDefault().asyncExec(() -> {
+            AbstractNotificationPopup notification = new ToolkitNotification(
+                Display.getDefault(),
+                Constants.MANIFEST_DEPRECATED_NOTIFICATION_TITLE,
+                Constants.MANIFEST_DEPRECATED_NOTIFICATION_BODY);
+            notification.open();
+        });
     }
 
     public static class Builder {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
@@ -18,11 +18,12 @@ public final class Constants {
     public static final String DO_NOT_SHOW_UPDATE_KEY = "doNotShowUpdate";
     public static final String PLUGIN_UPDATE_NOTIFICATION_TITLE = "Amazon Q Update Available";
     public static final String PLUGIN_UPDATE_NOTIFICATION_BODY = "Amazon Q plugin version %s is available."
-            + "Please update to receive the latest features and bug fixes.";
+            + " Please update to receive the latest features and bug fixes.";
     public static final String LSP_CW_OPT_OUT_KEY = "shareCodeWhispererContentWithAWS";
     public static final String LSP_CODE_REFERENCES_OPT_OUT_KEY = "includeSuggestionsWithCodeReferences";
     public static final String IDE_CUSTOMIZATION_NOTIFICATION_TITLE = "Amazon Q Customization";
     public static final String IDE_CUSTOMIZATION_NOTIFICATION_BODY_TEMPLATE = "Amazon Q inline suggestions are now coming from the %s";
+    public static final String MANIFEST_DEPRECATED_NOTIFICATION_KEY = "doNotShowDeprecatedManifest";
     public static final String MANIFEST_DEPRECATED_NOTIFICATION_TITLE = "Update Amazon Q Extension";
     public static final String MANIFEST_DEPRECATED_NOTIFICATION_BODY = "This version of the plugin will no longer receive updates to Amazon Q Language authoring features";
     public static final String DEFAULT_Q_FOUNDATION_DISPLAY_NAME = "Amazon Q foundation (Default)";

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
@@ -23,6 +23,8 @@ public final class Constants {
     public static final String LSP_CODE_REFERENCES_OPT_OUT_KEY = "includeSuggestionsWithCodeReferences";
     public static final String IDE_CUSTOMIZATION_NOTIFICATION_TITLE = "Amazon Q Customization";
     public static final String IDE_CUSTOMIZATION_NOTIFICATION_BODY_TEMPLATE = "Amazon Q inline suggestions are now coming from the %s";
+    public static final String MANIFEST_DEPRECATED_NOTIFICATION_TITLE = "Amazon Q Manifest Version is Deprecated";
+    public static final String MANIFEST_DEPRECATED_NOTIFICATION_BODY = "Current toolkit version will stop receiving updates. Please update the extension for continued support";
     public static final String DEFAULT_Q_FOUNDATION_DISPLAY_NAME = "Amazon Q foundation (Default)";
     public static final String LOGIN_TYPE_KEY = "LOGIN_TYPE";
     public static final String LOGIN_IDC_PARAMS_KEY = "IDC_PARAMS";

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
@@ -25,7 +25,8 @@ public final class Constants {
     public static final String IDE_CUSTOMIZATION_NOTIFICATION_BODY_TEMPLATE = "Amazon Q inline suggestions are now coming from the %s";
     public static final String MANIFEST_DEPRECATED_NOTIFICATION_KEY = "doNotShowDeprecatedManifest";
     public static final String MANIFEST_DEPRECATED_NOTIFICATION_TITLE = "Update Amazon Q Extension";
-    public static final String MANIFEST_DEPRECATED_NOTIFICATION_BODY = "This version of the plugin will no longer receive updates to Amazon Q Language authoring features";
+    public static final String MANIFEST_DEPRECATED_NOTIFICATION_BODY = "This version of the plugin"
+            + " will no longer receive updates to Amazon Q Language authoring features";
     public static final String DEFAULT_Q_FOUNDATION_DISPLAY_NAME = "Amazon Q foundation (Default)";
     public static final String LOGIN_TYPE_KEY = "LOGIN_TYPE";
     public static final String LOGIN_IDC_PARAMS_KEY = "IDC_PARAMS";

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
@@ -24,7 +24,8 @@ public final class Constants {
     public static final String IDE_CUSTOMIZATION_NOTIFICATION_TITLE = "Amazon Q Customization";
     public static final String IDE_CUSTOMIZATION_NOTIFICATION_BODY_TEMPLATE = "Amazon Q inline suggestions are now coming from the %s";
     public static final String MANIFEST_DEPRECATED_NOTIFICATION_TITLE = "Amazon Q Manifest Version is Deprecated";
-    public static final String MANIFEST_DEPRECATED_NOTIFICATION_BODY = "Current toolkit version will stop receiving updates. Please update the extension for continued support";
+    public static final String MANIFEST_DEPRECATED_NOTIFICATION_BODY = "Current toolkit version will stop receiving updates."
+            + "Please update the extension for continued support";
     public static final String DEFAULT_Q_FOUNDATION_DISPLAY_NAME = "Amazon Q foundation (Default)";
     public static final String LOGIN_TYPE_KEY = "LOGIN_TYPE";
     public static final String LOGIN_IDC_PARAMS_KEY = "IDC_PARAMS";

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
@@ -23,9 +23,8 @@ public final class Constants {
     public static final String LSP_CODE_REFERENCES_OPT_OUT_KEY = "includeSuggestionsWithCodeReferences";
     public static final String IDE_CUSTOMIZATION_NOTIFICATION_TITLE = "Amazon Q Customization";
     public static final String IDE_CUSTOMIZATION_NOTIFICATION_BODY_TEMPLATE = "Amazon Q inline suggestions are now coming from the %s";
-    public static final String MANIFEST_DEPRECATED_NOTIFICATION_TITLE = "Amazon Q Manifest Version is Deprecated";
-    public static final String MANIFEST_DEPRECATED_NOTIFICATION_BODY = "Current toolkit version will stop receiving updates."
-            + "Please update the extension for continued support";
+    public static final String MANIFEST_DEPRECATED_NOTIFICATION_TITLE = "Update Amazon Q Extension";
+    public static final String MANIFEST_DEPRECATED_NOTIFICATION_BODY = "This version of the plugin will no longer receive updates to Amazon Q Language authoring features";
     public static final String DEFAULT_Q_FOUNDATION_DISPLAY_NAME = "Amazon Q foundation (Default)";
     public static final String LOGIN_TYPE_KEY = "LOGIN_TYPE";
     public static final String LOGIN_IDC_PARAMS_KEY = "IDC_PARAMS";

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/UpdateUtils.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/UpdateUtils.java
@@ -12,6 +12,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.Optional;
 
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.eclipse.mylyn.commons.ui.dialogs.AbstractNotificationPopup;
@@ -36,7 +37,9 @@ public final class UpdateUtils {
     }
 
     private UpdateUtils() {
-        mostRecentNotificationVersion = Activator.getPluginStore().getObject(Constants.DO_NOT_SHOW_UPDATE_KEY, ArtifactVersion.class);
+        mostRecentNotificationVersion = Optional.ofNullable(Activator.getPluginStore().get(Constants.DO_NOT_SHOW_UPDATE_KEY))
+                .map(ArtifactUtils::parseVersion)
+                .orElse(null);
         String localString = PluginClientMetadata.getInstance().getPluginVersion();
         localVersion = ArtifactUtils.parseVersion(localString.substring(0, localString.lastIndexOf(".")));
     }
@@ -108,7 +111,7 @@ public final class UpdateUtils {
                     String.format(Constants.PLUGIN_UPDATE_NOTIFICATION_BODY, remoteVersion.toString()),
                     (selected) -> {
                         if (selected) {
-                            Activator.getPluginStore().putObject(Constants.DO_NOT_SHOW_UPDATE_KEY, remoteVersion);
+                            Activator.getPluginStore().put(Constants.DO_NOT_SHOW_UPDATE_KEY, remoteVersion.toString());
                         } else {
                             Activator.getPluginStore().remove(Constants.DO_NOT_SHOW_UPDATE_KEY);
                         }


### PR DESCRIPTION
*Issue #311*

*Description of changes:*
This change adds a check that will render a UI notification to the user if the fetched manifest is marked as deprecated. Most recent changes to this PR added "do not show again" button, giving the user control over how the notification is handled. This PR also edits logic for plugin update notification to use semantic versioning added in PR #329 

Screenshot
<img width="519" alt="image" src="https://github.com/user-attachments/assets/bec81d5b-2ee3-4139-b7e3-de9952c2e654" />




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
