### PR TITLE
Support for suppressible Chat license acknowledgement

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/configuration/PluginStoreKeys.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/configuration/PluginStoreKeys.java
@@ -1,0 +1,14 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.configuration;
+
+public final class PluginStoreKeys {
+
+    private PluginStoreKeys() {
+        // Prevent instantiation
+    }
+
+    public static final String CHAT_DISCLAIMER_ACKNOWLEDGED = "qchatDisclaimerAcknowledged";
+
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProvider.java
@@ -45,7 +45,7 @@ public class QLspConnectionProvider extends AbstractLspConnectionProvider {
     protected final void addEnvironmentVariables(final Map<String, String> env) {
         String httpsProxyPreference = Activator.getDefault().getPreferenceStore().getString(AmazonQPreferencePage.HTTPS_PROXY);
         String caCertPreference = Activator.getDefault().getPreferenceStore().getString(AmazonQPreferencePage.CA_CERT);
-        if (!StringUtils.isEmpty(caCertPreference)) {
+        if (!StringUtils.isEmpty(httpsProxyPreference)) {
             env.put("HTTPS_PROXY", httpsProxyPreference);
         }
         if (!StringUtils.isEmpty(caCertPreference)) {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/LspConstants.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/LspConstants.java
@@ -25,5 +25,5 @@ public final class LspConstants {
     public static final String LSP_SUBDIRECTORY = "lsp";
     public static final String AMAZONQ_LSP_SUBDIRECTORY = Paths.get(LSP_SUBDIRECTORY, "AmazonQ").toString();
 
-    public static final VersionRange LSP_SUPPORTED_VERSION_RANGE = new VersionRange("[2.3.0, 2.3.10)");
+    public static final VersionRange LSP_SUPPORTED_VERSION_RANGE = new VersionRange("[3.0.0, 3.0.10)");
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatViewActionHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatViewActionHandler.java
@@ -2,7 +2,6 @@
 
 package software.aws.toolkits.eclipse.amazonq.views;
 
-
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -24,6 +23,7 @@ import org.eclipse.ui.PlatformUI;
 import software.aws.toolkits.eclipse.amazonq.chat.models.CopyToClipboardParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.InfoLinkClickParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.InsertToCursorPositionParams;
+import software.aws.toolkits.eclipse.amazonq.configuration.PluginStoreKeys;
 import software.aws.toolkits.eclipse.amazonq.exception.AmazonQPluginException;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.AuthFollowUpClickedParams;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.AuthFollowUpType;
@@ -116,6 +116,9 @@ public class AmazonQChatViewActionHandler implements ViewActionHandler {
             case AUTH_FOLLOW_UP_CLICKED:
                 AuthFollowUpClickedParams authFollowUpClickedParams = jsonHandler.convertObject(params, AuthFollowUpClickedParams.class);
                 handleAuthFollowUpClicked(authFollowUpClickedParams);
+                break;
+            case DISCLAIMER_ACKNOWLEDGED:
+                Activator.getPluginStore().put(PluginStoreKeys.CHAT_DISCLAIMER_ACKNOWLEDGED, "true");
                 break;
             default:
                 throw new AmazonQPluginException("Unexpected command received from Amazon Q Chat: " + command.toString());

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/Command.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/Command.java
@@ -24,6 +24,7 @@ public enum Command {
     CHAT_COPY_TO_CLIPBOARD("copyToClipboard"),
     CHAT_INSERT_TO_CURSOR_POSITION("insertToCursorPosition"),
     AUTH_FOLLOW_UP_CLICKED("authFollowUpClicked"), //Auth command handled in QChat webview
+    DISCLAIMER_ACKNOWLEDGED("disclaimerAcknowledged"),
 
     // Auth
     LOGIN_BUILDER_ID("loginBuilderId"),


### PR DESCRIPTION
*Description of changes:*
Adds support for the suppressible Chat license acknowledgement in the Q Chat UI. Upon acknowledgement the setting is persisted by the extension and passed to Mynah via init calls.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
