### PR TITLE
Add feature to notify users of new plugin version availability

### DIFF
--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Automatic-Module-Name: amazon.q.eclipse
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: software.aws.toolkits.eclipse.amazonq.plugin.Activator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.31.0",
- org.tukaani.xz,
+ org.tukaani.xz;bundle-version="1.9.0",
  org.eclipse.ui;bundle-version="3.205.100",
  org.eclipse.core.resources;bundle-version="3.20.100",
  org.eclipse.jface.text;bundle-version="3.25.100",

--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Automatic-Module-Name: amazon.q.eclipse
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: software.aws.toolkits.eclipse.amazonq.plugin.Activator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.31.0",
+ org.tukaani.xz,
  org.eclipse.ui;bundle-version="3.205.100",
  org.eclipse.core.resources;bundle-version="3.20.100",
  org.eclipse.jface.text;bundle-version="3.25.100",

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -48,11 +48,6 @@
             <version>2.0.1</version>
         </dependency>
         <dependency>
-            <groupId>org.tukaani</groupId>
-            <artifactId>xz</artifactId>
-            <version>1.9</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -48,6 +48,11 @@
             <version>2.0.1</version>
         </dependency>
         <dependency>
+            <groupId>org.tukaani</groupId>
+            <artifactId>xz</artifactId>
+            <version>1.9</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/LspStartupActivity.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/LspStartupActivity.java
@@ -25,6 +25,7 @@ import software.aws.toolkits.eclipse.amazonq.telemetry.ToolkitTelemetryProvider;
 import software.aws.toolkits.eclipse.amazonq.telemetry.metadata.ExceptionMetadata;
 import software.aws.toolkits.eclipse.amazonq.views.ViewConstants;
 import software.aws.toolkits.eclipse.amazonq.util.ToolkitNotification;
+import software.aws.toolkits.eclipse.amazonq.util.UpdateUtils;
 import org.eclipse.mylyn.commons.ui.dialogs.AbstractNotificationPopup;
 import software.aws.toolkits.eclipse.amazonq.views.actions.ToggleAutoTriggerContributionItem;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
@@ -55,6 +56,20 @@ public class LspStartupActivity implements IStartup {
             Activator.getLspProvider().getAmazonQServer();
             this.launchWebview();
         }
+        Job updateCheckJob = new Job("Check for updates") {
+            @Override
+            protected IStatus run(final IProgressMonitor monitor) {
+                try {
+                    UpdateUtils.getInstance().checkForUpdate();
+                } catch (Exception e) {
+                    return new Status(IStatus.WARNING, "amazonq", "Failed to check for updates", e);
+                }
+                return Status.OK_STATUS;
+            }
+        };
+
+        updateCheckJob.setPriority(Job.DECORATE);
+        updateCheckJob.schedule();
     }
 
     private void launchWebview() {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
@@ -17,7 +17,8 @@ public final class Constants {
     public static final String LSP_CW_CONFIGURATION_KEY = "aws.codeWhisperer";
     public static final String DO_NOT_SHOW_UPDATE_KEY = "doNotShowUpdate";
     public static final String PLUGIN_UPDATE_NOTIFICATION_TITLE = "Amazon Q Update Available";
-    public static final String PLUGIN_UPDATE_NOTIFICATION_BODY = "Amazon Q plugin version %s is available. Please update for newest features.";
+    public static final String PLUGIN_UPDATE_NOTIFICATION_BODY = "Amazon Q plugin version %s is available."
+            + "Please update to receive the latest features and bug fixes.";
     public static final String LSP_CW_OPT_OUT_KEY = "shareCodeWhispererContentWithAWS";
     public static final String LSP_CODE_REFERENCES_OPT_OUT_KEY = "includeSuggestionsWithCodeReferences";
     public static final String IDE_CUSTOMIZATION_NOTIFICATION_TITLE = "Amazon Q Customization";

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
@@ -15,6 +15,9 @@ public final class Constants {
     public static final String LSP_OPT_OUT_TELEMETRY_CONFIGURATION_KEY = "optOutTelemetry";
     public static final String LSP_Q_CONFIGURATION_KEY = "aws.q";
     public static final String LSP_CW_CONFIGURATION_KEY = "aws.codeWhisperer";
+    public static final String LAST_NOTIFIED_UPDATE_VERSION = "lastShownNotificationVersion";
+    public static final String PLUGIN_UPDATE_NOTIFICATION_TITLE = "Amazon Q Update Available";
+    public static final String PLUGIN_UPDATE_NOTIFICATION_BODY = "A new version of the Amazon Q plugin is available. Please update for newest features.";
     public static final String LSP_CW_OPT_OUT_KEY = "shareCodeWhispererContentWithAWS";
     public static final String LSP_CODE_REFERENCES_OPT_OUT_KEY = "includeSuggestionsWithCodeReferences";
     public static final String IDE_CUSTOMIZATION_NOTIFICATION_TITLE = "Amazon Q Customization";

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
@@ -15,9 +15,9 @@ public final class Constants {
     public static final String LSP_OPT_OUT_TELEMETRY_CONFIGURATION_KEY = "optOutTelemetry";
     public static final String LSP_Q_CONFIGURATION_KEY = "aws.q";
     public static final String LSP_CW_CONFIGURATION_KEY = "aws.codeWhisperer";
-    public static final String LAST_NOTIFIED_UPDATE_VERSION = "lastShownNotificationVersion";
+    public static final String DO_NOT_SHOW_UPDATE_KEY = "doNotShowUpdate";
     public static final String PLUGIN_UPDATE_NOTIFICATION_TITLE = "Amazon Q Update Available";
-    public static final String PLUGIN_UPDATE_NOTIFICATION_BODY = "A new version of the Amazon Q plugin is available. Please update for newest features.";
+    public static final String PLUGIN_UPDATE_NOTIFICATION_BODY = "Amazon Q plugin version %s is available. Please update for newest features.";
     public static final String LSP_CW_OPT_OUT_KEY = "shareCodeWhispererContentWithAWS";
     public static final String LSP_CODE_REFERENCES_OPT_OUT_KEY = "includeSuggestionsWithCodeReferences";
     public static final String IDE_CUSTOMIZATION_NOTIFICATION_TITLE = "Amazon Q Customization";

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/PersistentToolkitNotification.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/PersistentToolkitNotification.java
@@ -1,0 +1,84 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.util;
+
+import org.eclipse.swt.events.MouseAdapter;
+import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.FontData;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
+
+import java.util.function.Consumer;
+import org.eclipse.swt.SWT;
+
+public final class PersistentToolkitNotification extends ToolkitNotification {
+    private final Consumer<Boolean> checkboxCallback;
+
+    public PersistentToolkitNotification(Display display, String title, String description, Consumer<Boolean> checkboxCallback) {
+        super(display, title, description);
+        this.checkboxCallback = checkboxCallback;
+    }
+
+    @Override
+    protected void createContentArea(final Composite parent) {
+        super.createContentArea(parent);
+
+        Composite container = (Composite) parent.getChildren()[0];
+
+        // create checkbox
+        Button doNotShowCheckbox = new Button(container, SWT.CHECK);
+        GridData checkboxGridData = new GridData(SWT.BEGINNING, SWT.CENTER, false, false);
+        doNotShowCheckbox.setLayoutData(checkboxGridData);
+
+        // create checkbox button text
+        Label checkboxLabel = new Label(container, SWT.NONE);
+        checkboxLabel.setText("Don't show this message again");
+        checkboxLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+
+        // style button text
+        Color grayColor = new Color(parent.getDisplay(), 128, 128, 128);
+        checkboxLabel.setForeground(grayColor);
+
+        Font originalFont = checkboxLabel.getFont();
+        FontData[] fontData = originalFont.getFontData();
+        for (FontData fd : fontData) {
+            fd.setHeight(fd.getHeight() - 1);
+        }
+        Font smallerFont = new Font(parent.getDisplay(), fontData);
+        checkboxLabel.setFont(smallerFont);
+
+        checkboxLabel.addDisposeListener(e -> {
+            smallerFont.dispose();
+            grayColor.dispose();
+        });
+
+        // make button text clickable
+        checkboxLabel.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseUp(MouseEvent e) {
+                doNotShowCheckbox.setSelection(!doNotShowCheckbox.getSelection());
+                if (checkboxCallback != null) {
+                    checkboxCallback.accept(doNotShowCheckbox.getSelection());
+                }
+            }
+        });
+
+        doNotShowCheckbox.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                if (checkboxCallback != null) {
+                    checkboxCallback.accept(doNotShowCheckbox.getSelection());
+                }
+            }
+        });
+    }
+
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/PersistentToolkitNotification.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/PersistentToolkitNotification.java
@@ -22,7 +22,8 @@ import org.eclipse.swt.SWT;
 public final class PersistentToolkitNotification extends ToolkitNotification {
     private final Consumer<Boolean> checkboxCallback;
 
-    public PersistentToolkitNotification(Display display, String title, String description, Consumer<Boolean> checkboxCallback) {
+    public PersistentToolkitNotification(final Display display, final String title,
+            final String description, final Consumer<Boolean> checkboxCallback) {
         super(display, title, description);
         this.checkboxCallback = checkboxCallback;
     }
@@ -63,7 +64,7 @@ public final class PersistentToolkitNotification extends ToolkitNotification {
         // make button text clickable
         checkboxLabel.addMouseListener(new MouseAdapter() {
             @Override
-            public void mouseUp(MouseEvent e) {
+            public void mouseUp(final MouseEvent e) {
                 doNotShowCheckbox.setSelection(!doNotShowCheckbox.getSelection());
                 if (checkboxCallback != null) {
                     checkboxCallback.accept(doNotShowCheckbox.getSelection());
@@ -73,7 +74,7 @@ public final class PersistentToolkitNotification extends ToolkitNotification {
 
         doNotShowCheckbox.addSelectionListener(new SelectionAdapter() {
             @Override
-            public void widgetSelected(SelectionEvent e) {
+            public void widgetSelected(final SelectionEvent e) {
                 if (checkboxCallback != null) {
                     checkboxCallback.accept(doNotShowCheckbox.getSelection());
                 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/ToolkitNotification.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/ToolkitNotification.java
@@ -43,6 +43,12 @@ public class ToolkitNotification extends AbstractNotificationPopup {
         return this.infoIcon;
     }
 
+    /**
+     * Creates the content area for the notification.
+     * Subclasses may override this method to customize the notification content.
+     *
+     * @param parent the parent composite
+     */
     @Override
     protected void createContentArea(final Composite parent) {
         Composite container = new Composite(parent, SWT.NONE);
@@ -59,12 +65,12 @@ public class ToolkitNotification extends AbstractNotificationPopup {
     }
 
     @Override
-    protected String getPopupShellTitle() {
+    protected final String getPopupShellTitle() {
         return this.title;
     }
 
     @Override
-    protected void initializeBounds() {
+    protected final void initializeBounds() {
         Rectangle clArea = getPrimaryClientArea();
         Point initialSize = getShell().computeSize(SWT.DEFAULT, SWT.DEFAULT);
         int height = Math.max(initialSize.y, MIN_HEIGHT);
@@ -105,7 +111,7 @@ public class ToolkitNotification extends AbstractNotificationPopup {
     }
 
     @Override
-    public boolean close() {
+    public final boolean close() {
         activeNotifications.remove(this);
         repositionNotifications();
         if (this.infoIcon != null && !this.infoIcon.isDisposed()) {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/ToolkitNotification.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/ToolkitNotification.java
@@ -19,7 +19,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.mylyn.commons.ui.dialogs.AbstractNotificationPopup;
 
-public final class ToolkitNotification extends AbstractNotificationPopup {
+public class ToolkitNotification extends AbstractNotificationPopup {
 
     private final String title;
     private final String description;

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/UpdateUtils.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/UpdateUtils.java
@@ -1,0 +1,119 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.util;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.eclipse.mylyn.commons.ui.dialogs.AbstractNotificationPopup;
+import org.eclipse.swt.widgets.Display;
+import org.osgi.framework.Version;
+
+import org.tukaani.xz.XZInputStream;
+
+import software.aws.toolkits.eclipse.amazonq.exception.AmazonQPluginException;
+import software.aws.toolkits.eclipse.amazonq.lsp.manager.fetcher.ArtifactUtils;
+import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
+import software.aws.toolkits.eclipse.amazonq.telemetry.metadata.PluginClientMetadata;
+
+public class UpdateUtils {
+    //env for this link?
+    private static final String requestURL = "https://amazonq.eclipsetoolkit.amazonwebservices.com/artifacts.xml.xz";
+    private static Version mostRecentNotificationVersion;
+    private static Version remoteVersion;
+    private static Version localVersion;
+    private static final UpdateUtils INSTANCE = new UpdateUtils();
+
+    public static UpdateUtils getInstance() {
+        return INSTANCE;
+    }
+
+    private UpdateUtils() {
+        mostRecentNotificationVersion = Activator.getPluginStore().getObject(Constants.LAST_NOTIFIED_UPDATE_VERSION, Version.class);
+        String localString = PluginClientMetadata.getInstance().getPluginVersion();
+        localVersion = ArtifactUtils.parseVersion(localString.substring(0, localString.lastIndexOf(".")));
+    }
+
+    private boolean newUpdateAvailable() {
+        //fetch artifact file containing version info from repo
+        remoteVersion = fetchRemoteArtifactVersion(requestURL);
+
+        //return early if either version is unavailable
+        if (remoteVersion == null || localVersion == null) {
+            return false;
+        }
+
+        //prompt should show if never previously displayed or remote version is greater
+        boolean shouldShowNotification = mostRecentNotificationVersion == null || remoteVersionIsGreater(remoteVersion, mostRecentNotificationVersion);
+
+        return remoteVersionIsGreater(remoteVersion, localVersion) && shouldShowNotification;
+    }
+
+    public void checkForUpdate() {
+        if (newUpdateAvailable()) {
+            //notify user
+            showNotification();
+
+            //update storage with notification version
+            Activator.getPluginStore().putObject(Constants.LAST_NOTIFIED_UPDATE_VERSION, remoteVersion);
+        }
+    }
+
+    private Version fetchRemoteArtifactVersion(String repositoryUrl) {
+        HttpURLConnection connection = null;
+        try {
+            URL url = new URL(repositoryUrl);
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+            connection.setConnectTimeout(5000);
+            connection.setReadTimeout(5000);
+
+            // handle response codes
+            int responseCode = connection.getResponseCode();
+            if (responseCode != HttpURLConnection.HTTP_OK) {
+                throw new AmazonQPluginException("HTTP request failed with response code: " + responseCode);
+            }
+
+            // process XZ content from input stream
+            try (InputStream inputStream = connection.getInputStream();
+                 XZInputStream xzis = new XZInputStream(inputStream);
+                 BufferedReader reader = new BufferedReader(new InputStreamReader(xzis))) {
+
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (line.contains("<artifact classifier=\"osgi.bundle\"")) {
+                        int versionStart = line.indexOf("version=\"") + 9;
+                        int versionEnd = line.indexOf("\"", versionStart);
+                        String fullVersion = line.substring(versionStart, versionEnd);
+                        return ArtifactUtils.parseVersion(fullVersion.substring(0, fullVersion.lastIndexOf(".")));
+                    }
+                }
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+        return null;
+    }
+
+    private void showNotification() {
+        Display.getDefault().asyncExec(() -> {
+            AbstractNotificationPopup notification = new ToolkitNotification(Display.getCurrent(),
+                    Constants.PLUGIN_UPDATE_NOTIFICATION_TITLE,
+                    Constants.PLUGIN_UPDATE_NOTIFICATION_BODY);
+            notification.open();
+        });
+    }
+
+    private static boolean remoteVersionIsGreater(Version remote, Version local) {
+        return (remote != null) && (local != null) && (remote.compareTo(local) > 0);
+    }
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/UpdateUtils.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/UpdateUtils.java
@@ -20,9 +20,9 @@ import software.aws.toolkits.eclipse.amazonq.lsp.manager.fetcher.ArtifactUtils;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
 import software.aws.toolkits.eclipse.amazonq.telemetry.metadata.PluginClientMetadata;
 
-public class UpdateUtils {
+public final class UpdateUtils {
     //env for this link?
-    private static final String requestURL = "https://amazonq.eclipsetoolkit.amazonwebservices.com/artifacts.xml.xz";
+    private static final String REQUESTURL = "https://amazonq.eclipsetoolkit.amazonwebservices.com/artifacts.xml.xz";
     private static Version mostRecentNotificationVersion;
     private static Version remoteVersion;
     private static Version localVersion;
@@ -40,7 +40,7 @@ public class UpdateUtils {
 
     private boolean newUpdateAvailable() {
         //fetch artifact file containing version info from repo
-        remoteVersion = fetchRemoteArtifactVersion(requestURL);
+        remoteVersion = fetchRemoteArtifactVersion(REQUESTURL);
 
         //return early if either version is unavailable
         if (remoteVersion == null || localVersion == null) {
@@ -59,7 +59,7 @@ public class UpdateUtils {
         }
     }
 
-    private Version fetchRemoteArtifactVersion(String repositoryUrl) {
+    private Version fetchRemoteArtifactVersion(final String repositoryUrl) {
         HttpURLConnection connection = null;
         try {
             URL url = new URL(repositoryUrl);
@@ -116,7 +116,7 @@ public class UpdateUtils {
         });
     }
 
-    private static boolean remoteVersionIsGreater(Version remote, Version local) {
+    private static boolean remoteVersionIsGreater(final Version remote, final Version local) {
         return remote.compareTo(local) > 0;
     }
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/UpdateUtils.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/UpdateUtils.java
@@ -96,7 +96,7 @@ public final class UpdateUtils {
             }
 
         } catch (Exception e) {
-            e.printStackTrace();
+            Activator.getLogger().error("Error fetching artifact from remote location.", e);
         }
         return null;
     }


### PR DESCRIPTION
_Issue #313_ 

*Description of changes:*
This addition sends the user a notification each time a new version of the plugin is made available on the marketplace. 
This includes:
* addition of dependency to decompress XZ file containing version information from eclipse marketplace
* additional notification type that features "do not show again" checkbox, giving users choice of persistent notification
* UpdateUtil file which handles fetching version info from eclipse marketplace and determining if notification should be shown

*Screenshot:*
<img width="516" alt="Screenshot 2025-01-09 at 4 08 18 PM" src="https://github.com/user-attachments/assets/4bb2fcf8-fd69-4141-ad13-e5efffcfa66e" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
