### PR TITLE
Fix to make disclaimer acknowledgement check null-safe

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
@@ -247,7 +247,7 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
                     window.addEventListener('load', init);
                 </script>
                 """, jsEntrypoint, getWaitFunction(), chatQuickActionConfig,
-                disclaimerAcknowledged.equals("true"));
+                "true".equals(disclaimerAcknowledged));
     }
 
     /*


### PR DESCRIPTION
*Description of changes:*
Currently, the disclaimer acknowledgement boolean check can cause an exception if the field in persistent storage is null, which leaves the plugin's webview in an unresponsive state. This change adds null-safety to the check, ensuring proper functionality of the acknowledgement and webview.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
