### PR TITLE
Determine and send inline completion session result

### DIFF
--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -25,7 +25,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.31.0",
  org.eclipse.jetty.util;bundle-version="12.0.9",
  org.eclipse.core.net;bundle-version="1.5.400",
  org.apache.commons.logging;bundle-version="1.2.0",
- slf4j.api;bundle-version="2.0.13"
+ slf4j.api;bundle-version="2.0.13",
+ org.apache.commons.lang3;bundle-version="3.14.0"
 Bundle-Classpath: target/classes/,
  target/dependency/annotations-2.28.26.jar,
  target/dependency/apache-client-2.28.26.jar,

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/handlers/QAcceptSuggestionsHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/handlers/QAcceptSuggestionsHandler.java
@@ -25,6 +25,8 @@ public class QAcceptSuggestionsHandler extends AbstractHandler {
         var suggestion = QInvocationSession.getInstance().getCurrentSuggestion();
         var widget = QInvocationSession.getInstance().getViewer().getTextWidget();
         var session = QInvocationSession.getInstance();
+        // mark current suggestion as accepted
+        session.setAccepted(suggestion.getItemId());
         session.setSuggestionAccepted(true);
         session.transitionToDecisionMade();
         Display display = widget.getDisplay();

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServer.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServer.java
@@ -22,6 +22,7 @@ import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.UpdateProfileParams;
 import software.aws.toolkits.eclipse.amazonq.lsp.model.GetConfigurationFromServerParams;
 import software.aws.toolkits.eclipse.amazonq.lsp.model.InlineCompletionParams;
 import software.aws.toolkits.eclipse.amazonq.lsp.model.InlineCompletionResponse;
+import software.aws.toolkits.eclipse.amazonq.lsp.model.LogInlineCompletionSessionResultsParams;
 import software.aws.toolkits.eclipse.amazonq.lsp.model.LspServerConfigurations;
 import software.aws.toolkits.eclipse.amazonq.lsp.model.UpdateCredentialsPayload;
 
@@ -29,6 +30,9 @@ public interface AmazonQLspServer extends LanguageServer {
 
     @JsonRequest("aws/textDocument/inlineCompletionWithReferences")
     CompletableFuture<InlineCompletionResponse> inlineCompletionWithReferences(InlineCompletionParams params);
+
+    @JsonNotification("aws/logInlineCompletionSessionResults")
+    void logInlineCompletionSessionResult(LogInlineCompletionSessionResultsParams params);
 
     @JsonRequest("aws/chat/sendChatPrompt")
     CompletableFuture<String> sendChatPrompt(EncryptedChatParams encryptedChatRequestParams);

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/model/InlineCompletionStates.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/model/InlineCompletionStates.java
@@ -1,0 +1,43 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.lsp.model;
+
+public final class InlineCompletionStates {
+    // Indicates if suggestion has been seen by the user in the UI
+    private boolean seen;
+    // Indicates if suggestion accepted
+    private boolean accepted;
+    // Indicates if suggestion was filtered out on the client-side and marked as
+    // discarded.
+    private boolean discarded;
+
+    public boolean isSeen() {
+        return seen;
+    }
+
+    public void setSeen(final boolean seen) {
+        this.seen = seen;
+    }
+
+    public boolean isAccepted() {
+        return accepted;
+    }
+
+    public void setAccepted(final boolean accepted) {
+        this.accepted = accepted;
+    }
+
+    public boolean isDiscarded() {
+        return discarded;
+    }
+
+    public void setDiscarded(final boolean discarded) {
+        this.discarded = discarded;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("{accepted=%b, seen=%b, discarded=%b}", accepted, seen, discarded);
+    }
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/model/LogInlineCompletionSessionResultsParams.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/model/LogInlineCompletionSessionResultsParams.java
@@ -1,0 +1,63 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.lsp.model;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+public final class LogInlineCompletionSessionResultsParams {
+    // Session Id attached to get completion items response
+    private final String sessionId;
+    // Map with results of interaction with completion items/suggestions in the  UI
+    private final ConcurrentHashMap<String, InlineCompletionStates> completionSessionResult;
+
+    // Total time when items from this suggestion session were visible in UI
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Long totalSessionDisplayTime;
+    // Time from request invocation start to rendering of the first suggestion in the UI.
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Long firstCompletionDisplayLatency;
+    // Length of additional characters inputed by user from when the trigger happens to when the first suggestion is about to be shown in UI
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Integer typeaheadLength;
+
+    public LogInlineCompletionSessionResultsParams(final String sessionId, final ConcurrentHashMap<String, InlineCompletionStates> completionSessionResult) {
+        this.sessionId = sessionId;
+        this.completionSessionResult = completionSessionResult;
+    }
+
+    public Long getTotalSessionDisplayTime() {
+        return totalSessionDisplayTime;
+    }
+
+    public void setTotalSessionDisplayTime(final Long totalSessionDisplayTime) {
+        this.totalSessionDisplayTime = totalSessionDisplayTime;
+    }
+
+    public Long getFirstCompletionDisplayLatency() {
+        return firstCompletionDisplayLatency;
+    }
+
+    public void setFirstCompletionDisplayLatency(final Long firstCompletionDisplayLatency) {
+        this.firstCompletionDisplayLatency = firstCompletionDisplayLatency;
+    }
+
+    public Integer getTypeaheadLength() {
+        return typeaheadLength;
+    }
+
+    public void setTypeaheadLength(final Integer typeaheadLength) {
+        this.typeaheadLength = typeaheadLength;
+    }
+
+    public ConcurrentHashMap<String, InlineCompletionStates> getCompletionSessionResult() {
+        return completionSessionResult;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QInlineInputListener.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QInlineInputListener.java
@@ -274,18 +274,35 @@ public final class QInlineInputListener implements IDocumentListener, VerifyKeyL
         }
         String currentSuggestion = session.getCurrentSuggestion().getInsertText();
         int currentOffset = widget.getCaretOffset();
+
         if (input.isEmpty()) {
+            Activator.getLogger().info("distance traversed is 1:" + distanceTraversed);
             if (distanceTraversed <= 0) {
+                // discard all suggestions as caret position is less than request invocation position
+                session.updateCompletionStates(new ArrayList<String>());
                 session.transitionToDecisionMade();
                 session.end();
                 return;
             }
             distanceTraversed = typeaheadProcessor.getNewDistanceTraversedOnDeleteAndUpdateBracketState(
                     event.getLength(), distanceTraversed, brackets);
+            Activator.getLogger().info("distance traversed is" + distanceTraversed);
             if (distanceTraversed < 0) {
+                // discard all suggestions as caret position is less than request invocation position
+                session.updateCompletionStates(new ArrayList<String>());
                 session.transitionToDecisionMade();
                 session.end();
             }
+
+            // note: distanceTraversed as 0 is currently understood to be when a user presses BS removing any typeahead
+            if (distanceTraversed == 0) {
+                // reset completion states for all suggestions when user reverts to request
+                // invocation state
+                session.resetCompletionStates();
+                // mark currently displayed suggestion as seen
+                session.markSuggestionAsSeen();
+            }
+
             return;
         }
 
@@ -328,11 +345,18 @@ public final class QInlineInputListener implements IDocumentListener, VerifyKeyL
             session.transitionToDecisionMade(lineToUnsetIndent);
             Display.getCurrent().asyncExec(() -> {
                 if (session.isActive()) {
-                    session.end();
+                    // discard suggestions and end immediately as typeahead does not match
+                    session.updateCompletionStates(new ArrayList<String>());
+                    session.endImmediately();
                 }
             });
             return;
         }
+
+        // discard all other suggestions except for current one as typeahead matches it
+        // also mark current one as seen as it continues to be displayed
+        session.updateCompletionStates(List.of(session.getCurrentSuggestion().getItemId()));
+        session.markSuggestionAsSeen();
 
         // Here we perform "post closing bracket insertion caret correction", which
         // consists of the following:
@@ -398,7 +422,7 @@ public final class QInlineInputListener implements IDocumentListener, VerifyKeyL
         int currentOffset = invocationOffset + distanceTraversed;
         int lastKnownLine = widget.getLineAtOffset(currentOffset);
         qInvocationSessionInstance.transitionToDecisionMade(lastKnownLine + 1);
-        qInvocationSessionInstance.end();
+        qInvocationSessionInstance.endImmediately();
         return;
     }
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QInlineInputListener.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QInlineInputListener.java
@@ -276,7 +276,6 @@ public final class QInlineInputListener implements IDocumentListener, VerifyKeyL
         int currentOffset = widget.getCaretOffset();
 
         if (input.isEmpty()) {
-            Activator.getLogger().info("distance traversed is 1:" + distanceTraversed);
             if (distanceTraversed <= 0) {
                 // discard all suggestions as caret position is less than request invocation position
                 session.updateCompletionStates(new ArrayList<String>());
@@ -286,7 +285,6 @@ public final class QInlineInputListener implements IDocumentListener, VerifyKeyL
             }
             distanceTraversed = typeaheadProcessor.getNewDistanceTraversedOnDeleteAndUpdateBracketState(
                     event.getLength(), distanceTraversed, brackets);
-            Activator.getLogger().info("distance traversed is" + distanceTraversed);
             if (distanceTraversed < 0) {
                 // discard all suggestions as caret position is less than request invocation position
                 session.updateCompletionStates(new ArrayList<String>());

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QSuggestionsContext.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QSuggestionsContext.java
@@ -4,10 +4,17 @@
 package software.aws.toolkits.eclipse.amazonq.util;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+
+import software.aws.toolkits.eclipse.amazonq.lsp.model.InlineCompletionStates;
 
 public class QSuggestionsContext {
     private List<QSuggestionContext> details = new ArrayList<>();
+    private String sessionId;
+    private HashMap<String, InlineCompletionStates> suggestionCompletionResults = new HashMap<String, InlineCompletionStates>();
+
+    private long requestedAtEpoch;
     private int currentIndex = -1;
 
     public QSuggestionsContext() {
@@ -39,6 +46,22 @@ public class QSuggestionsContext {
 
     public final int getNumberOfSuggestions() {
         return details.size();
+    }
+
+    public final String getSessionId() {
+        return sessionId;
+    }
+
+    public final void setSessionId(final String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public final long getRequestedAtEpoch() {
+        return requestedAtEpoch;
+    }
+
+    public final void setRequestedAtEpoch(final long requestedAtEpoch) {
+        this.requestedAtEpoch = requestedAtEpoch;
     }
 }
 

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/util/QInvocationSessionTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/util/QInvocationSessionTest.java
@@ -248,6 +248,7 @@ public class QInvocationSessionTest {
         localizedActivatorMock.when(Activator::getLspProvider).thenReturn(mockLspProvider);
         potentResponse = mock(InlineCompletionResponse.class);
         impotentResponse = mock(InlineCompletionResponse.class);
+        when(potentResponse.getSessionId()).thenReturn("sample-sessionId");
         when(potentResponse.getItems()).thenReturn(new ArrayList<>(getInlineCompletionItems()));
         when(impotentResponse.getItems()).thenReturn(Collections.emptyList());
         LoggingService loggingServiceMock = mock(LoggingService.class);


### PR DESCRIPTION
*Description of changes:*
This change adds support to send InlineCompletionSession result to lsp. This `logInlineCompletionSessionResults` notification is used to communicate information about user interactions in UI with list of suggestions received for telemetry instrumentation. 
Modifications have been made to the QInvocationSession class which is responsible for managing querying the LSP and showing suggestions in the UI. It maintains a map of each suggestion to it's completion state and populates them as user sees/accepts/filters/rejects a suggestion. Final inline completion result is sent when a session is accepted or dismissed.
Testing
Verified states of accept, reject, discard and ignore were being emitted with "userDecision" and "userTriggerDecision" metrics.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
