### PR TITLE
Fall back to default chat options if LSP is unavailable

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AwsServerCapabiltiesProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AwsServerCapabiltiesProvider.java
@@ -2,12 +2,30 @@
 
 package software.aws.toolkits.eclipse.amazonq.lsp;
 
+import java.util.Arrays;
+import java.util.Collections;
+
 import software.aws.toolkits.eclipse.amazonq.lsp.model.AwsServerCapabilities;
 import software.aws.toolkits.eclipse.amazonq.lsp.model.ChatOptions;
+import software.aws.toolkits.eclipse.amazonq.lsp.model.Command;
+import software.aws.toolkits.eclipse.amazonq.lsp.model.QuickActions;
+import software.aws.toolkits.eclipse.amazonq.lsp.model.QuickActionsCommandGroup;
 
 public final class AwsServerCapabiltiesProvider {
     private static AwsServerCapabiltiesProvider instance;
     private AwsServerCapabilities serverCapabilties;
+    private static final ChatOptions DEFAULT_CHAT_OPTIONS = new ChatOptions(
+            new QuickActions(
+                Collections.singletonList(
+                    new QuickActionsCommandGroup(
+                        Arrays.asList(
+                            new Command("/help", "Learn more about Amazon Q"),
+                            new Command("/clear", "Clear this session")
+                        )
+                    )
+                )
+            )
+        );
 
     public static synchronized AwsServerCapabiltiesProvider getInstance() {
         if (instance == null) {
@@ -24,6 +42,6 @@ public final class AwsServerCapabiltiesProvider {
         if (serverCapabilties != null) {
             return serverCapabilties.chatOptions();
         }
-        return null;
+        return DEFAULT_CHAT_OPTIONS;
     }
 }


### PR DESCRIPTION
*Description of changes:*
Creates a static list of default chat options/commands in the case of the LSP being unavailable when the Chat UI is starting up. The LSP is intended to be the authoritative source of this metadata, but due to a race condition issue it often is not available and these commands never get wired up. This is absolutely not a long term solution but does address the customer experience break while we investigate a better solution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
