### PR TITLE
Handle invalid proxy URLs

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProvider.java
@@ -18,6 +18,7 @@ import software.aws.toolkits.eclipse.amazonq.lsp.manager.fetcher.RecordLspSetupA
 import software.aws.toolkits.eclipse.amazonq.providers.LspManagerProvider;
 import software.aws.toolkits.eclipse.amazonq.telemetry.LanguageServerTelemetryProvider;
 import software.aws.toolkits.eclipse.amazonq.telemetry.metadata.ExceptionMetadata;
+import software.aws.toolkits.eclipse.amazonq.util.ProxyUtil;
 import software.aws.toolkits.telemetry.TelemetryDefinitions.Result;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
 import software.aws.toolkits.eclipse.amazonq.preferences.AmazonQPreferencePage;
@@ -43,7 +44,7 @@ public class QLspConnectionProvider extends AbstractLspConnectionProvider {
 
     @Override
     protected final void addEnvironmentVariables(final Map<String, String> env) {
-        String httpsProxyPreference = Activator.getDefault().getPreferenceStore().getString(AmazonQPreferencePage.HTTPS_PROXY);
+        String httpsProxyPreference = ProxyUtil.getHttpsProxyUrl();
         String caCertPreference = Activator.getDefault().getPreferenceStore().getString(AmazonQPreferencePage.CA_CERT);
         if (!StringUtils.isEmpty(httpsProxyPreference)) {
             env.put("HTTPS_PROXY", httpsProxyPreference);

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/preferences/AmazonQPreferencePage.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/preferences/AmazonQPreferencePage.java
@@ -193,6 +193,7 @@ public class AmazonQPreferencePage extends FieldEditorPreferencePage implements 
         addField(httpsProxy);
         createLabel("""
                 Sets the address of the proxy to use for all HTTPS connections. \
+                For example "http://localhost:8888". \
                 Leave blank if not using a proxy.
                 Eclipse restart required to take effect.
                 """, 20, getFieldEditorParent());

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
@@ -40,5 +40,7 @@ public final class Constants {
     public static final String AUTHENTICATE_FAILURE_MESSAGE = "An error occurred while attempting to authenticate. Please try again.";
     public static final String IDE_SSL_HANDSHAKE_TITLE = "SSL Handshake Error";
     public static final String IDE_SSL_HANDSHAKE_BODY = "The plugin encountered an SSL handshake error. If using a proxy, check the plugin preferences.";
+    public static final String INVALID_PROXY_CONFIGURATION_TITLE = "Proxy Configuration Error";
+    public static final String INVALID_PROXY_CONFIGURATION_BODY = "The provided proxy URL is invalid. Please check your plugin configuration.";
 
 }

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/util/ProxyUtilTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/util/ProxyUtilTest.java
@@ -4,7 +4,13 @@
 package software.aws.toolkits.eclipse.amazonq.util;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+import org.eclipse.swt.widgets.Display;
 
 class ProxyUtilTest {
 
@@ -29,6 +35,26 @@ class ProxyUtilTest {
     void testPreferenceProxyUrlPrecedence() {
         String mockUrl = "http://foo.com:8888";
         assertEquals(mockUrl, ProxyUtil.getHttpsProxyUrl("http://bar.com:8888", mockUrl));
+    }
+
+    @Test
+    void testEnvVarInvalidProxyUrl() {
+        try (MockedStatic<Display> displayMock = mockStatic(Display.class)) {
+            Display mockDisplay = mock(Display.class);
+            displayMock.when(Display::getDefault).thenReturn(mockDisplay);
+            String mockUrl = "127.0.0.1:8000";
+            assertEquals(null, ProxyUtil.getHttpsProxyUrl(mockUrl, null));
+        }
+    }
+
+    @Test
+    void testPreferenceInvalidProxyUrl() {
+        try (MockedStatic<Display> displayMock = mockStatic(Display.class)) {
+            Display mockDisplay = mock(Display.class);
+            displayMock.when(Display::getDefault).thenReturn(mockDisplay);
+            String mockUrl = "127.0.0.1:8000";
+            assertEquals(null, ProxyUtil.getHttpsProxyUrl(null, mockUrl));
+        }
     }
 
 }


### PR DESCRIPTION
*Description of changes:*
Validates that configured (via preference) or passed (via environment variable) proxy URLs are valid before using them. URLs are parsed for correctness and ignored if invalid. Additionally, a prompt is shown to the user.

![Screenshot 2025-01-24 at 2 38 00 PM](https://github.com/user-attachments/assets/981d37d3-a76c-4a13-a62b-9c6f9ed88766)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
