### PR TITLE
Update syncDependencies script to fix classpath conflicts

### DIFF
--- a/plugin/build/syncDependencies.sh
+++ b/plugin/build/syncDependencies.sh
@@ -19,7 +19,7 @@ if [ ! -f "$manifest_file" ]; then
 fi
 
 # Initialize the Bundle-Classpath entry
-bundle_classpath="Bundle-Classpath: target/classes/,\n"
+bundle_classpath="Bundle-Classpath: .,\n"
 
 # Loop through the JAR files in the dependency directory
 for jar in "$dependency_dir"/*.jar; do


### PR DESCRIPTION
*Description of changes:*
This configuration was invalid and leading Maven Tycho to treat the `target/classes` directory as a library instead of an output directory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
