### PR TITLE
Update Flare version constraint

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/LspConstants.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/LspConstants.java
@@ -32,7 +32,7 @@ public final class LspConstants {
 
     private static VersionRange createVersionRange() {
         try {
-            return VersionRange.createFromVersionSpec("[3.0.0, 3.0.10)");
+            return VersionRange.createFromVersionSpec("[3.1.0, 3.1.10)");
         } catch (InvalidVersionSpecificationException e) {
             throw new AmazonQPluginException("Failed to parse LSP supported version range", e);
         }


### PR DESCRIPTION
*Description of changes:*
3.1.0 is out.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
