### PR TITLE
Add functionality for hot event streams that track latest event

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/broker/EventBroker.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/broker/EventBroker.java
@@ -21,7 +21,6 @@ public final class EventBroker {
 
     public EventBroker() {
         eventBus = BehaviorSubject.create().toSerialized();
-
         cachedObservables = new ConcurrentHashMap<>();
         eventBus.doOnNext(event -> getOrCreateObservable(event.getClass())).subscribe();
     }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/broker/EventBroker.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/broker/EventBroker.java
@@ -3,17 +3,28 @@
 
 package software.aws.toolkits.eclipse.amazonq.broker;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.disposables.Disposable;
-import io.reactivex.rxjava3.functions.Consumer;
+import io.reactivex.rxjava3.observables.ConnectableObservable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
-import io.reactivex.rxjava3.subjects.PublishSubject;
+import io.reactivex.rxjava3.subjects.BehaviorSubject;
 import io.reactivex.rxjava3.subjects.Subject;
 import software.aws.toolkits.eclipse.amazonq.broker.api.EventObserver;
 
 public final class EventBroker {
 
-    private final Subject<Object> eventBus = PublishSubject.create().toSerialized();
+    private final Subject<Object> eventBus;
+    private final Map<Class<?>, Observable<?>> cachedObservables;
+
+    public EventBroker() {
+        eventBus = BehaviorSubject.create().toSerialized();
+
+        cachedObservables = new ConcurrentHashMap<>();
+        eventBus.doOnNext(event -> getOrCreateObservable(event.getClass())).subscribe();
+    }
 
     public <T> void post(final T event) {
         if (event == null) {
@@ -22,21 +33,23 @@ public final class EventBroker {
         eventBus.onNext(event);
     }
 
-    public <T> Disposable subscribe(final Class<T> eventType, final EventObserver<T> observer) {
-        Consumer<T> consumer = new Consumer<>() {
-            @Override
-            public void accept(final T event) {
-                observer.onEvent(event);
-            }
-        };
+    @SuppressWarnings("unchecked")
+    private <T> Observable<T> getOrCreateObservable(final Class<T> eventType) {
+        return (Observable<T>) cachedObservables.computeIfAbsent(eventType, type -> {
+            ConnectableObservable<?> observable = eventBus.ofType(type).replay(1);
+            observable.connect();
+            return observable;
+        });
+    }
 
-        return eventBus.ofType(eventType)
+    public <T> Disposable subscribe(final Class<T> eventType, final EventObserver<T> observer) {
+        return getOrCreateObservable(eventType)
                 .observeOn(Schedulers.computation())
-                .subscribe(consumer);
+                .subscribe(observer::onEvent);
     }
 
     public <T> Observable<T> ofObservable(final Class<T> eventType) {
-        return eventBus.ofType(eventType);
+        return getOrCreateObservable(eventType);
     }
 
 }

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/broker/EventBrokerTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/broker/EventBrokerTest.java
@@ -129,6 +129,7 @@ public final class EventBrokerTest {
 
         firstTestEventSubscription.dispose();
         secondTestEventSubscription.dispose();
+        otherEventSubscription.dispose();
     }
 
     @Test


### PR DESCRIPTION
*Issue #314*

*Description of changes:*
- Event bus uses a `BehaviorSubject` instead of `PublishSubject` because `PublishSubject` doesn't emit when new subscribers join, while `BehaviorSubject` will try to publish event if at-least one event of any type has been received on the bus prior to new subscription.
- The `Observable` streams are now "hot" emitting events as soon as the publisher is ready regardless of whether there are subscribers downstream. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
