### PR TITLE
Pass populated AWS_CA_BUNDLE env var to Flare

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProvider.java
@@ -51,6 +51,7 @@ public class QLspConnectionProvider extends AbstractLspConnectionProvider {
         }
         if (!StringUtils.isEmpty(caCertPreference)) {
             env.put("NODE_EXTRA_CA_CERTS", caCertPreference);
+            env.put("AWS_CA_BUNDLE", caCertPreference);
         }
         env.put("ENABLE_INLINE_COMPLETION", "true");
         env.put("ENABLE_TOKEN_PROVIDER", "true");


### PR DESCRIPTION
*Description of changes:*
Additionally pass a value for `AWS_CA_BUNDLE` to Flare along with `NODE_EXTRA_CA_CERTS`. This value is explicitly used by Flare for certificates and, although it should be a no-op in most cases, ensures that CA certs will be consistently used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
