### PR TITLE
Disable arrow keys if text area is empty

### DIFF
--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -28,7 +28,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.31.0",
  org.apache.commons.logging;bundle-version="1.2.0",
  slf4j.api;bundle-version="2.0.13",
  org.apache.commons.lang3;bundle-version="3.14.0"
-Bundle-Classpath: .,
+Bundle-Classpath: target/classes/,
  target/dependency/annotations-2.28.26.jar,
  target/dependency/apache-client-2.28.26.jar,
  target/dependency/auth-2.28.26.jar,

--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -28,7 +28,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.31.0",
  org.apache.commons.logging;bundle-version="1.2.0",
  slf4j.api;bundle-version="2.0.13",
  org.apache.commons.lang3;bundle-version="3.14.0"
-Bundle-Classpath: target/classes/,
+Bundle-Classpath: .,
  target/dependency/annotations-2.28.26.jar,
  target/dependency/apache-client-2.28.26.jar,
  target/dependency/auth-2.28.26.jar,

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
@@ -3,6 +3,8 @@
 
 package software.aws.toolkits.eclipse.amazonq.views;
 
+import java.awt.Toolkit;
+import java.awt.datatransfer.StringSelection;
 import java.util.List;
 import java.util.Optional;
 
@@ -26,6 +28,8 @@ import software.aws.toolkits.eclipse.amazonq.lsp.model.QuickActions;
 import software.aws.toolkits.eclipse.amazonq.lsp.model.QuickActionsCommandGroup;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
 import software.aws.toolkits.eclipse.amazonq.util.ObjectMapperFactory;
+import software.aws.toolkits.eclipse.amazonq.util.PluginPlatform;
+import software.aws.toolkits.eclipse.amazonq.util.PluginUtils;
 import software.aws.toolkits.eclipse.amazonq.util.ThreadingUtils;
 import software.aws.toolkits.eclipse.amazonq.views.actions.AmazonQCommonActions;
 
@@ -91,12 +95,31 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
         amazonQCommonActions = getAmazonQCommonActions();
 
         chatCommunicationManager.setChatUiRequestListener(this);
+
         new BrowserFunction(browser, "ideCommand") {
             @Override
             public Object function(final Object[] arguments) {
                 ThreadingUtils.executeAsyncTask(() -> {
                     handleMessageFromUI(browser, arguments);
                 });
+                return null;
+            }
+        };
+
+        new BrowserFunction(browser, "isMacOs") {
+            @Override
+            public Object function(final Object[] arguments) {
+                return Boolean.TRUE.equals(PluginUtils.getPlatform() == PluginPlatform.MAC);
+            }
+        };
+
+        new BrowserFunction(browser, "copyToClipboard") {
+            @Override
+            public Object function(final Object[] arguments) {
+                if (arguments.length > 0 && arguments[0] instanceof String) {
+                    StringSelection stringSelection = new StringSelection((String) arguments[0]);
+                    Toolkit.getDefaultToolkit().getSystemClipboard().setContents(stringSelection, null);
+                }
                 return null;
             }
         };
@@ -210,6 +233,16 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
                         mask-position: center;
                         scale: 60%;
                     }
+                    .mynah-button.mynah-button-secondary.fill-state-always.code-snippet-close-button.mynah-ui-clickable-item
+                    .mynah-ui-icon-cancel {
+                        -webkit-mask-size: 187.5% !important;
+                        mask-size: 187.5% !important;
+                        mask-position: center;
+                        aspect-ratio: 1/1;
+                        width: 15px;
+                        height: 15px;
+                        scale: 50%
+                    }
                     .mynah-ui-icon-tabs {
                         -webkit-mask-size: 102% !important;
                         mask-size: 102% !important;
@@ -272,7 +305,78 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
                             });
                         }
                     });
-                </script>
+
+                    window.addEventListener('load', () => {
+                        const textarea = document.querySelector('textarea.mynah-chat-prompt-input');
+                        if (textarea) {
+                            textarea.addEventListener("keydown", (event) => {
+                                if (((isMacOs() && event.metaKey) || (!isMacOs() && event.ctrlKey)) && event.key === 'a') {
+                                    textarea.select();
+                                    event.preventDefault();
+                                    event.stopPropagation();
+                                }
+                            });
+                        }
+                    });
+
+                    window.addEventListener('load', () => {
+                        const textarea = document.querySelector('textarea.mynah-chat-prompt-input');
+                        if (textarea) {
+                            textarea.addEventListener("keydown", (event) => {
+                                if (((isMacOs() && event.metaKey) || (!isMacOs() && event.ctrlKey)) && event.key === 'c') {
+                                    copyToClipboard(textarea.value);
+                                    event.preventDefault();
+                                    event.stopPropagation();
+                                }
+                            });
+                        }
+                    });
+
+
+                const observer = new MutationObserver((mutations) => {
+                    try {
+                        mutations.forEach((mutation) => {
+                            mutation.addedNodes.forEach((node) => {
+                                if (node.nodeType === 1) { // Check if it's an element node
+                                    // Check for direct match
+                                    if (node.matches('.mynah-button.mynah-button-secondary.mynah-button-border.fill-state-always.mynah-chat-item-followup-question-option.mynah-ui-clickable-item')) {
+                                        attachEventListeners(node);
+                                    }
+
+                                    // Check for nested matches
+                                    const buttons = node.querySelectorAll('.mynah-button.mynah-button-secondary.mynah-button-border.fill-state-always.mynah-chat-item-followup-question-option.mynah-ui-clickable-item');
+                                    buttons.forEach(attachEventListeners);
+                                }
+                            });
+                        });
+                    } catch (error) {
+                        console.error('Error in mutation observer:', error);
+                    }
+                });
+
+                function attachEventListeners(element) {
+                    if (!element || element.dataset.hasListener) return; // Prevent duplicate listeners
+
+                    element.addEventListener('mouseover', function(event) {
+                        const textSpan = this.querySelector('span.mynah-button-label');
+                        if (textSpan && textSpan.scrollWidth <= textSpan.offsetWidth) {
+                            event.stopImmediatePropagation();
+                            event.stopPropagation();
+                            event.preventDefault();
+                        }
+                    }, true);
+                    element.dataset.hasListener = 'true';
+                }
+
+                try {
+                    observer.observe(document.body, {
+                        childList: true,
+                        subtree: true
+                    });
+                } catch (error) {
+                    console.error('Error starting observer:', error);
+                }
+                 </script>
                 """, jsEntrypoint, getWaitFunction(), chatQuickActionConfig,
                 "true".equals(disclaimerAcknowledged));
     }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
@@ -21,7 +21,6 @@ import software.aws.toolkits.eclipse.amazonq.chat.ChatTheme;
 import software.aws.toolkits.eclipse.amazonq.configuration.PluginStoreKeys;
 import software.aws.toolkits.eclipse.amazonq.lsp.AwsServerCapabiltiesProvider;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.AuthState;
-import software.aws.toolkits.eclipse.amazonq.lsp.manager.LspStatusManager;
 import software.aws.toolkits.eclipse.amazonq.lsp.model.ChatOptions;
 import software.aws.toolkits.eclipse.amazonq.lsp.model.QuickActions;
 import software.aws.toolkits.eclipse.amazonq.lsp.model.QuickActionsCommandGroup;
@@ -142,7 +141,7 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
                 // chat view
                 if (browser != null && !browser.isDisposed() && !chatStateManager.hasPreservedState()) {
                     Optional<String> content = getContent();
-                    if (!content.isPresent() && !LspStatusManager.lspFailed()) {
+                    if (!content.isPresent()) {
                         canDisposeState = true;
                         ViewVisibilityManager.showChatAssetMissingView("update");
                     } else {
@@ -260,7 +259,6 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
                                         if (!hasText || cursorPosition === 0) {
                                             event.preventDefault();
                                             event.stopPropagation();
-                                            return false;
                                         }
                                         break;
 
@@ -268,12 +266,8 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
                                         if (!hasText || cursorPosition === textarea.value.length) {
                                             event.preventDefault();
                                             event.stopPropagation();
-                                            return false;
                                         }
                                         break;
-
-                                    default:
-                                    return true;
                                 }
                             });
                         }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
@@ -280,111 +280,16 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
 
                     window.addEventListener('load', init);
 
-                    window.addEventListener('load', () => {
-                        const textarea = document.querySelector('textarea.mynah-chat-prompt-input');
-                        if (textarea) {
-                            textarea.addEventListener('keydown', (event) => {
-                                const cursorPosition = textarea.selectionStart;
-                                const hasText = textarea.value.length > 0;
+                    %s
 
-                                // block arrow keys on empty text area
-                                switch (event.key) {
-                                    case 'ArrowLeft':
-                                        if (!hasText || cursorPosition === 0) {
-                                            event.preventDefault();
-                                            event.stopPropagation();
-                                        }
-                                        break;
+                    %s
 
-                                    case 'ArrowRight':
-                                        if (!hasText || cursorPosition === textarea.value.length) {
-                                            event.preventDefault();
-                                            event.stopPropagation();
-                                        }
-                                        break;
-                                }
-                            });
-                        }
-                    });
+                    %s
 
-                    window.addEventListener('load', () => {
-                        const textarea = document.querySelector('textarea.mynah-chat-prompt-input');
-                        if (textarea) {
-                            textarea.addEventListener("keydown", (event) => {
-                                if (((isMacOs() && event.metaKey) || (!isMacOs() && event.ctrlKey))
-                                        && event.key === 'a') {
-                                    textarea.select();
-                                    event.preventDefault();
-                                    event.stopPropagation();
-                                }
-                            });
-                        }
-                    });
-
-                    window.addEventListener('load', () => {
-                        const textarea = document.querySelector('textarea.mynah-chat-prompt-input');
-                        if (textarea) {
-                            textarea.addEventListener("keydown", (event) => {
-                                if (((isMacOs() && event.metaKey) || (!isMacOs() && event.ctrlKey)) && event.key === 'c') {
-                                    copyToClipboard(textarea.value);
-                                    event.preventDefault();
-                                    event.stopPropagation();
-                                }
-                            });
-                        }
-                    });
-
-
-                const observer = new MutationObserver((mutations) => {
-                    try {
-                        mutations.forEach((mutation) => {
-                            mutation.addedNodes.forEach((node) => {
-                                if (node.nodeType === 1) { // Check if it's an element node
-                                    // Check for direct match
-                                    if (node.matches('.mynah-button.mynah-button-secondary
-                                            .mynah-button-border.fill-state-always.mynah-chat-item-followup-question-option
-                                            .mynah-ui-clickable-item')) {
-                                        attachEventListeners(node);
-                                    }
-
-                                    // Check for nested matches
-                                    const buttons = node.querySelectorAll('.mynah-button.mynah-button-secondary
-                                        .mynah-button-border.fill-state-always.mynah-chat-item-followup-question-option
-                                        .mynah-ui-clickable-item');
-                                    buttons.forEach(attachEventListeners);
-                                }
-                            });
-                        });
-                    } catch (error) {
-                        console.error('Error in mutation observer:', error);
-                    }
-                });
-
-                function attachEventListeners(element) {
-                    if (!element || element.dataset.hasListener) return; // Prevent duplicate listeners
-
-                    element.addEventListener('mouseover', function(event) {
-                        const textSpan = this.querySelector('span.mynah-button-label');
-                        if (textSpan && textSpan.scrollWidth <= textSpan.offsetWidth) {
-                            event.stopImmediatePropagation();
-                            event.stopPropagation();
-                            event.preventDefault();
-                        }
-                    }, true);
-                    element.dataset.hasListener = 'true';
-                }
-
-                try {
-                    observer.observe(document.body, {
-                        childList: true,
-                        subtree: true
-                    });
-                } catch (error) {
-                    console.error('Error starting observer:', error);
-                }
-                 </script>
+                </script>
                 """, jsEntrypoint, getWaitFunction(), chatQuickActionConfig,
-                "true".equals(disclaimerAcknowledged));
+                "true".equals(disclaimerAcknowledged), getArrowKeyBlockingFunction(),
+                getSelectAllAndCopySupportFunctions(), getPreventEmptyPopupFunction());
     }
 
     /*
@@ -406,6 +311,118 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
             Activator.getLogger().warn("Error occurred when json serializing quick action commands", e);
             return "";
         }
+    }
+
+    private String getArrowKeyBlockingFunction() {
+        return """
+                window.addEventListener('load', () => {
+                    const textarea = document.querySelector('textarea.mynah-chat-prompt-input');
+                    if (textarea) {
+                        textarea.addEventListener('keydown', (event) => {
+                            const cursorPosition = textarea.selectionStart;
+                            const hasText = textarea.value.length > 0;
+
+                            // block arrow keys on empty text area
+                            switch (event.key) {
+                                case 'ArrowLeft':
+                                    if (!hasText || cursorPosition === 0) {
+                                        event.preventDefault();
+                                        event.stopPropagation();
+                                    }
+                                    break;
+
+                                case 'ArrowRight':
+                                    if (!hasText || cursorPosition === textarea.value.length) {
+                                        event.preventDefault();
+                                        event.stopPropagation();
+                                    }
+                                    break;
+                            }
+                        });
+                    }
+                });
+                """;
+    }
+
+    private String getSelectAllAndCopySupportFunctions() {
+        return """
+                window.addEventListener('load', () => {
+                    const textarea = document.querySelector('textarea.mynah-chat-prompt-input');
+                    if (textarea) {
+                        textarea.addEventListener("keydown", (event) => {
+                            if (((isMacOs() && event.metaKey) || (!isMacOs() && event.ctrlKey))
+                                    && event.key === 'a') {
+                                textarea.select();
+                                event.preventDefault();
+                                event.stopPropagation();
+                            }
+                        });
+                    }
+                });
+
+                window.addEventListener('load', () => {
+                    const textarea = document.querySelector('textarea.mynah-chat-prompt-input');
+                    if (textarea) {
+                        textarea.addEventListener("keydown", (event) => {
+                            if (((isMacOs() && event.metaKey) || (!isMacOs() && event.ctrlKey))
+                                    && event.key === 'c') {
+                                copyToClipboard(textarea.value);
+                                event.preventDefault();
+                                event.stopPropagation();
+                            }
+                        });
+                    }
+                });
+                """;
+    }
+
+    private String getPreventEmptyPopupFunction() {
+        String selector = ".mynah-button" + ".mynah-button-secondary.mynah-button-border" + ".fill-state-always"
+                + ".mynah-chat-item-followup-question-option" + ".mynah-ui-clickable-item";
+
+        return """
+                const observer = new MutationObserver((mutations) => {
+                    try {
+                        const selector = '%s';
+
+                        mutations.forEach((mutation) => {
+                            mutation.addedNodes.forEach((node) => {
+                                if (node.nodeType === 1) { // Check if it's an element node
+                                    // Check for direct match
+                                    if (node.matches(selector)) {
+                                        attachEventListeners(node);
+                                    }
+                                    // Check for nested matches
+                                    const buttons = node.querySelectorAll();
+                                    buttons.forEach(attachEventListeners);
+                                }
+                            });
+                        });
+                    } catch (error) {
+                        console.error('Error in mutation observer:', error);
+                    }
+                });
+                function attachEventListeners(element) {
+                    if (!element || element.dataset.hasListener) return; // Prevent duplicate listeners
+                    element.addEventListener('mouseover', function(event) {
+                        const textSpan = this.querySelector('span.mynah-button-label');
+                        if (textSpan && textSpan.scrollWidth <= textSpan.offsetWidth) {
+                            event.stopImmediatePropagation();
+                            event.stopPropagation();
+                            event.preventDefault();
+                        }
+                    }, true);
+                    element.dataset.hasListener = 'true';
+                }
+                try {
+                    observer.observe(document.body, {
+                        childList: true,
+                        subtree: true
+                    });
+                } catch (error) {
+                    console.error('Error starting observer:', error);
+                }
+                """.formatted(selector);
     }
 
     @Override

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
@@ -233,7 +233,8 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
                         mask-position: center;
                         scale: 60%;
                     }
-                    .mynah-button.mynah-button-secondary.fill-state-always.code-snippet-close-button.mynah-ui-clickable-item
+                    .mynah-button.mynah-button-secondary.fill-state-always.code-snippet-close-button
+                    .mynah-ui-clickable-item
                     .mynah-ui-icon-cancel {
                         -webkit-mask-size: 187.5% !important;
                         mask-size: 187.5% !important;
@@ -310,7 +311,8 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
                         const textarea = document.querySelector('textarea.mynah-chat-prompt-input');
                         if (textarea) {
                             textarea.addEventListener("keydown", (event) => {
-                                if (((isMacOs() && event.metaKey) || (!isMacOs() && event.ctrlKey)) && event.key === 'a') {
+                                if (((isMacOs() && event.metaKey) || (!isMacOs() && event.ctrlKey))
+                                        && event.key === 'a') {
                                     textarea.select();
                                     event.preventDefault();
                                     event.stopPropagation();
@@ -339,12 +341,16 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
                             mutation.addedNodes.forEach((node) => {
                                 if (node.nodeType === 1) { // Check if it's an element node
                                     // Check for direct match
-                                    if (node.matches('.mynah-button.mynah-button-secondary.mynah-button-border.fill-state-always.mynah-chat-item-followup-question-option.mynah-ui-clickable-item')) {
+                                    if (node.matches('.mynah-button.mynah-button-secondary
+                                            .mynah-button-border.fill-state-always.mynah-chat-item-followup-question-option
+                                            .mynah-ui-clickable-item')) {
                                         attachEventListeners(node);
                                     }
 
                                     // Check for nested matches
-                                    const buttons = node.querySelectorAll('.mynah-button.mynah-button-secondary.mynah-button-border.fill-state-always.mynah-chat-item-followup-question-option.mynah-ui-clickable-item');
+                                    const buttons = node.querySelectorAll('.mynah-button.mynah-button-secondary
+                                        .mynah-button-border.fill-state-always.mynah-chat-item-followup-question-option
+                                        .mynah-ui-clickable-item');
                                     buttons.forEach(attachEventListeners);
                                 }
                             });


### PR DESCRIPTION
*Issue #348*

*Description of changes:*
- Added an event listener to check if text area is empty and block the propagation of arrow key events in mynah if no text exists that can be navigated.
- This prevents unrecognized characters from being rendered in the chat.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
