### PR TITLE
Pass through auth token to Q server without decrypting

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/auth/AuthCredentialsService.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/auth/AuthCredentialsService.java
@@ -7,7 +7,9 @@ import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage;
 
+import software.aws.toolkits.eclipse.amazonq.lsp.model.UpdateCredentialsPayload;
+
 public interface AuthCredentialsService {
-    CompletableFuture<ResponseMessage> updateTokenCredentials(String accessToken, boolean isEncrypted);
+    CompletableFuture<ResponseMessage> updateTokenCredentials(UpdateCredentialsPayload params);
     CompletableFuture<Void> deleteTokenCredentials();
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/auth/AuthTokenService.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/auth/AuthTokenService.java
@@ -5,13 +5,13 @@ package software.aws.toolkits.eclipse.amazonq.lsp.auth;
 
 import java.util.concurrent.CompletableFuture;
 
+import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.GetSsoTokenResult;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.InvalidateSsoTokenParams;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.InvalidateSsoTokenResult;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.LoginParams;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.LoginType;
-import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.SsoToken;
 
 public interface AuthTokenService {
-    CompletableFuture<SsoToken> getSsoToken(LoginType loginType, LoginParams loginParams, boolean loginOnInvalidToken);
+    CompletableFuture<GetSsoTokenResult> getSsoToken(LoginType loginType, LoginParams loginParams, boolean loginOnInvalidToken);
     CompletableFuture<InvalidateSsoTokenResult> invalidateSsoToken(InvalidateSsoTokenParams invalidateSsoTokenParams);
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/auth/DefaultAuthCredentialsService.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/auth/DefaultAuthCredentialsService.java
@@ -9,20 +9,15 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage;
 
 import software.aws.toolkits.eclipse.amazonq.exception.AmazonQPluginException;
-import software.aws.toolkits.eclipse.amazonq.lsp.encryption.LspEncryptionManager;
-import software.aws.toolkits.eclipse.amazonq.lsp.model.BearerCredentials;
 import software.aws.toolkits.eclipse.amazonq.lsp.model.UpdateCredentialsPayload;
-import software.aws.toolkits.eclipse.amazonq.lsp.model.UpdateCredentialsPayloadData;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
 import software.aws.toolkits.eclipse.amazonq.providers.LspProvider;
 
 public final class DefaultAuthCredentialsService implements AuthCredentialsService {
     private LspProvider lspProvider;
-    private LspEncryptionManager encryptionManager;
 
     private DefaultAuthCredentialsService(final Builder builder) {
         this.lspProvider = Objects.requireNonNull(builder.lspProvider, "lspProvider must not be null");
-        this.encryptionManager = Objects.requireNonNull(builder.encryptionManager, "encryptionManager must not be null");
     }
 
     public static Builder builder() {
@@ -30,14 +25,9 @@ public final class DefaultAuthCredentialsService implements AuthCredentialsServi
     }
 
     @Override
-    public CompletableFuture<ResponseMessage> updateTokenCredentials(final String accessToken, final boolean isEncrypted) {
-        String token = accessToken;
-        if (isEncrypted) {
-            token = decryptSsoToken(accessToken);
-        }
-        UpdateCredentialsPayload payload = createUpdateCredentialsPayload(token);
+    public CompletableFuture<ResponseMessage> updateTokenCredentials(final UpdateCredentialsPayload params) {
         return lspProvider.getAmazonQServer()
-                .thenCompose(server -> server.updateTokenCredentials(payload))
+                .thenCompose(server -> server.updateTokenCredentials(params))
                 .exceptionally(throwable -> {
                     throw new AmazonQPluginException("Failed to update token credentials", throwable);
                 });
@@ -52,30 +42,11 @@ public final class DefaultAuthCredentialsService implements AuthCredentialsServi
                 });
     }
 
-    private String decryptSsoToken(final String encryptedSsoToken) {
-        String decryptedToken = encryptionManager.decrypt(encryptedSsoToken);
-        return decryptedToken.substring(1, decryptedToken.length() - 1); // Remove extra quotes surrounding token
-    }
-
-    private UpdateCredentialsPayload createUpdateCredentialsPayload(final String ssoToken) {
-        BearerCredentials credentials = new BearerCredentials();
-        credentials.setToken(ssoToken);
-
-        UpdateCredentialsPayloadData data = new UpdateCredentialsPayloadData(credentials);
-        String encryptedData = encryptionManager.encrypt(data);
-        return new UpdateCredentialsPayload(encryptedData, true);
-    }
-
     public static class Builder {
         private LspProvider lspProvider;
-        private LspEncryptionManager encryptionManager;
 
         public final Builder withLspProvider(final LspProvider lspProvider) {
             this.lspProvider = lspProvider;
-            return this;
-        }
-        public final Builder withEncryptionManager(final LspEncryptionManager encryptionManager) {
-            this.encryptionManager = encryptionManager;
             return this;
         }
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/auth/DefaultAuthTokenService.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/auth/DefaultAuthTokenService.java
@@ -13,6 +13,7 @@ import software.amazon.awssdk.services.toolkittelemetry.model.AWSProduct;
 import software.aws.toolkits.eclipse.amazonq.exception.AmazonQPluginException;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.GetSsoTokenOptions;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.GetSsoTokenParams;
+import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.GetSsoTokenResult;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.GetSsoTokenSource;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.InvalidateSsoTokenParams;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.InvalidateSsoTokenResult;
@@ -22,7 +23,6 @@ import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.Profile;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.ProfileSettings;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.SsoSession;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.SsoSessionSettings;
-import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.SsoToken;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.UpdateProfileOptions;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.UpdateProfileParams;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
@@ -41,7 +41,7 @@ public final class DefaultAuthTokenService implements AuthTokenService {
     }
 
     @Override
-    public CompletableFuture<SsoToken> getSsoToken(final LoginType loginType, final LoginParams loginParams,
+    public CompletableFuture<GetSsoTokenResult> getSsoToken(final LoginType loginType, final LoginParams loginParams,
                 final boolean loginOnInvalidToken) {
         GetSsoTokenParams getSsoTokenParams = createGetSsoTokenParams(loginType, loginOnInvalidToken);
         return lspProvider.getAmazonQServer()
@@ -70,7 +70,7 @@ public final class DefaultAuthTokenService implements AuthTokenService {
                 })
                 .thenCompose(server -> server.getSsoToken(getSsoTokenParams))
                 .thenApply(response -> {
-                    return response.ssoToken();
+                    return response;
                 })
                 .exceptionally(throwable -> {
                     throw new AmazonQPluginException("Failed to fetch SSO token", throwable);

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/auth/model/GetSsoTokenResult.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/auth/model/GetSsoTokenResult.java
@@ -3,4 +3,6 @@
 
 package software.aws.toolkits.eclipse.amazonq.lsp.auth.model;
 
-public record GetSsoTokenResult(SsoToken ssoToken) { }
+import software.aws.toolkits.eclipse.amazonq.lsp.model.UpdateCredentialsPayload;
+
+public record GetSsoTokenResult(SsoToken ssoToken, UpdateCredentialsPayload updateCredentialsParams) { }

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/lsp/auth/DefaultAuthTokenServiceTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/lsp/auth/DefaultAuthTokenServiceTest.java
@@ -77,10 +77,10 @@ public final class DefaultAuthTokenServiceTest {
         when(mockSsoTokenResult.ssoToken()).thenReturn(expectedToken);
         boolean loginOnInvalidToken = false;
 
-        SsoToken actualToken = invokeGetSsoToken(loginType, loginParams, loginOnInvalidToken);
+        GetSsoTokenResult result = invokeGetSsoToken(loginType, loginParams, loginOnInvalidToken);
 
-        assertEquals(expectedToken.id(), actualToken.id());
-        assertEquals(expectedToken.accessToken(), actualToken.accessToken());
+        assertEquals(expectedToken.id(), result.ssoToken().id());
+        assertEquals(expectedToken.accessToken(), result.ssoToken().accessToken());
         verify(mockAmazonQServer).getSsoToken(any(GetSsoTokenParams.class));
         verifyNoMoreInteractions(mockAmazonQServer);
     }
@@ -93,10 +93,10 @@ public final class DefaultAuthTokenServiceTest {
         when(mockSsoTokenResult.ssoToken()).thenReturn(expectedToken);
         boolean loginOnInvalidToken = true;
 
-        SsoToken actualToken = invokeGetSsoToken(loginType, loginParams, loginOnInvalidToken);
+        GetSsoTokenResult result = invokeGetSsoToken(loginType, loginParams, loginOnInvalidToken);
 
-        assertEquals(expectedToken.id(), actualToken.id());
-        assertEquals(expectedToken.accessToken(), actualToken.accessToken());
+        assertEquals(expectedToken.id(), result.ssoToken().id());
+        assertEquals(expectedToken.accessToken(), result.ssoToken().accessToken());
         verify(mockAmazonQServer).getSsoToken(any(GetSsoTokenParams.class));
         verifyNoMoreInteractions(mockAmazonQServer);
     }
@@ -109,10 +109,10 @@ public final class DefaultAuthTokenServiceTest {
         when(mockSsoTokenResult.ssoToken()).thenReturn(expectedToken);
         boolean loginOnInvalidToken = false;
 
-        SsoToken actualToken = invokeGetSsoToken(loginType, loginParams, loginOnInvalidToken);
+        GetSsoTokenResult result = invokeGetSsoToken(loginType, loginParams, loginOnInvalidToken);
 
-        assertEquals(expectedToken.id(), actualToken.id());
-        assertEquals(expectedToken.accessToken(), actualToken.accessToken());
+        assertEquals(expectedToken.id(), result.ssoToken().id());
+        assertEquals(expectedToken.accessToken(), result.ssoToken().accessToken());
         verify(mockAmazonQServer).getSsoToken(any(GetSsoTokenParams.class));
         verifyNoMoreInteractions(mockAmazonQServer);
     }
@@ -129,10 +129,10 @@ public final class DefaultAuthTokenServiceTest {
         when(mockSsoTokenResult.ssoToken()).thenReturn(expectedToken);
         boolean loginOnInvalidToken = true;
 
-        SsoToken actualToken = invokeGetSsoToken(loginType, loginParams, loginOnInvalidToken);
+        GetSsoTokenResult result = invokeGetSsoToken(loginType, loginParams, loginOnInvalidToken);
 
-        assertEquals(expectedToken.id(), actualToken.id());
-        assertEquals(expectedToken.accessToken(), actualToken.accessToken());
+        assertEquals(expectedToken.id(), result.ssoToken().id());
+        assertEquals(expectedToken.accessToken(), result.ssoToken().accessToken());
         verify(mockAmazonQServer).updateProfile(updateProfileParamsCaptor.capture());
         UpdateProfileParams actualParams = updateProfileParamsCaptor.getValue();
         verifyUpdateProfileParams(actualParams);
@@ -140,15 +140,15 @@ public final class DefaultAuthTokenServiceTest {
         verifyNoMoreInteractions(mockAmazonQServer);
     }
 
-    private SsoToken invokeGetSsoToken(final LoginType loginType, final LoginParams loginParams, final boolean loginOnInvalidToken) throws Exception {
+    private GetSsoTokenResult invokeGetSsoToken(final LoginType loginType, final LoginParams loginParams, final boolean loginOnInvalidToken) throws Exception {
         Object getSsoTokenFuture = authTokenService.getSsoToken(loginType, loginParams, loginOnInvalidToken);
         assertTrue(getSsoTokenFuture instanceof CompletableFuture<?>, "Return value should be CompletableFuture");
 
         CompletableFuture<?> future = (CompletableFuture<?>) getSsoTokenFuture;
         Object result = future.get();
-        assertTrue(result instanceof SsoToken, "getSsoTokenFuture result should be SsoToken");
+        assertTrue(result instanceof GetSsoTokenResult, "getSsoTokenFuture result should be GetSsoTokenResult");
 
-        return (SsoToken) result;
+        return (GetSsoTokenResult) result;
     }
 
     private LoginParams createValidLoginParams() {


### PR DESCRIPTION
*Description of changes:*
Change avoids an unnecessary step of decrypting and re-encrypting SSO tokens received from the auth component before updating the Q server component.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
