### PR TITLE
Fix potential memory visibility bug

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQViewContainer.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQViewContainer.java
@@ -15,7 +15,6 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.part.ViewPart;
 
-import io.reactivex.rxjava3.disposables.Disposable;
 import software.aws.toolkits.eclipse.amazonq.broker.api.EventObserver;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
 import software.aws.toolkits.eclipse.amazonq.views.actions.AmazonQStaticActions;
@@ -28,9 +27,8 @@ public final class AmazonQViewContainer extends ViewPart implements EventObserve
     private Composite parentComposite;
     private StackLayout layout;
     private Map<AmazonQViewType, BaseAmazonQView> views;
-    private AmazonQViewType activeViewType;
-    private BaseAmazonQView currentView;
-    private Disposable activeViewTypeSubscription;
+    private volatile AmazonQViewType activeViewType;
+    private volatile BaseAmazonQView currentView;
     private final ReentrantLock containerLock;
 
     public AmazonQViewContainer() {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQViewContainer.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQViewContainer.java
@@ -25,7 +25,7 @@ public final class AmazonQViewContainer extends ViewPart implements EventObserve
     public static final String ID = "software.aws.toolkits.eclipse.amazonq.views.AmazonQViewContainer";
 
     private Composite parentComposite;
-    private StackLayout layout;
+    private volatile StackLayout layout;
     private Map<AmazonQViewType, BaseAmazonQView> views;
     private volatile AmazonQViewType activeViewType;
     private volatile BaseAmazonQView currentView;


### PR DESCRIPTION
*Issue #314*

*Description of changes:*
- Makes member variables accessed by multiple threads volatile so they see the latest value of the variable everytime.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
