### PR TITLE
Refactor view actions and move setup code to base view

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
@@ -118,6 +118,8 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
         }
         browser.setText(content.get());
 
+        setupAmazonQCommonActions();
+
         return parent;
     }
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQView.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQView.java
@@ -9,27 +9,14 @@ import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.IViewSite;
 
-import io.reactivex.rxjava3.disposables.Disposable;
-import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.AuthState;
-import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
 import software.aws.toolkits.eclipse.amazonq.providers.browser.AmazonQBrowserProvider;
 import software.aws.toolkits.eclipse.amazonq.util.ThemeDetector;
-import software.aws.toolkits.eclipse.amazonq.views.actions.AmazonQCommonActions;
 
 public abstract class AmazonQView extends BaseAmazonQView {
 
     private AmazonQBrowserProvider browserProvider;
-    private AmazonQCommonActions amazonQCommonActions;
     private static final ThemeDetector THEME_DETECTOR = new ThemeDetector();
-
-    private Disposable signOutActionAuthStateSubscription;
-    private Disposable feedbackDialogAuthStateSubscription;
-    private Disposable customizationDialogAuthStateSubscription;
-    private Disposable toggleAutoTriggerAuthStateSubscription;
-
-    private IViewSite viewSite;
 
     protected AmazonQView() {
         this.browserProvider = new AmazonQBrowserProvider();
@@ -37,10 +24,6 @@ public abstract class AmazonQView extends BaseAmazonQView {
 
     public final Browser getBrowser() {
         return browserProvider.getBrowser();
-    }
-
-    public final AmazonQCommonActions getAmazonQCommonActions() {
-        return amazonQCommonActions;
     }
 
     protected final void setupParentBackground(final Composite parent) {
@@ -77,8 +60,6 @@ public abstract class AmazonQView extends BaseAmazonQView {
 
         if (browser != null && !browser.isDisposed()) {
             setupBrowserBackground(parent);
-            setupActions();
-            setupAuthStatusListeners();
             disableBrowserContextMenu();
         }
 
@@ -92,25 +73,6 @@ public abstract class AmazonQView extends BaseAmazonQView {
     private void setupBrowserBackground(final Composite parent) {
         var bgColor = parent.getBackground();
         getBrowser().setBackground(bgColor);
-    }
-
-    private void setupActions() {
-        amazonQCommonActions = new AmazonQCommonActions(viewSite);
-    }
-
-    private void setupAuthStatusListeners() {
-        signOutActionAuthStateSubscription = Activator.getEventBroker().subscribe(AuthState.class,
-                amazonQCommonActions.getSignoutAction());
-        feedbackDialogAuthStateSubscription = Activator.getEventBroker().subscribe(AuthState.class,
-                amazonQCommonActions.getFeedbackDialogContributionAction());
-        customizationDialogAuthStateSubscription = Activator.getEventBroker().subscribe(AuthState.class,
-                amazonQCommonActions.getCustomizationDialogContributionAction());
-        toggleAutoTriggerAuthStateSubscription = Activator.getEventBroker().subscribe(AuthState.class,
-                amazonQCommonActions.getToggleAutoTriggerContributionAction());
-    }
-
-    public final void setViewSite(final IViewSite viewSite) {
-        this.viewSite = viewSite;
     }
 
     public final void addFocusListener(final Composite parent, final Browser browser) {
@@ -137,19 +99,7 @@ public abstract class AmazonQView extends BaseAmazonQView {
      */
     @Override
     public void dispose() {
-        if (signOutActionAuthStateSubscription != null && !signOutActionAuthStateSubscription.isDisposed()) {
-            signOutActionAuthStateSubscription.dispose();
-        }
-        if (feedbackDialogAuthStateSubscription != null && !feedbackDialogAuthStateSubscription.isDisposed()) {
-            feedbackDialogAuthStateSubscription.dispose();
-        }
-        if (customizationDialogAuthStateSubscription != null
-                && !customizationDialogAuthStateSubscription.isDisposed()) {
-            customizationDialogAuthStateSubscription.dispose();
-        }
-        if (toggleAutoTriggerAuthStateSubscription != null && !toggleAutoTriggerAuthStateSubscription.isDisposed()) {
-            toggleAutoTriggerAuthStateSubscription.dispose();
-        }
+        super.dispose();
     }
 
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQViewContainer.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQViewContainer.java
@@ -15,10 +15,8 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.part.ViewPart;
 
-import io.reactivex.rxjava3.disposables.Disposable;
 import software.aws.toolkits.eclipse.amazonq.broker.api.EventObserver;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
-import software.aws.toolkits.eclipse.amazonq.views.actions.AmazonQStaticActions;
 import software.aws.toolkits.eclipse.amazonq.views.router.AmazonQViewType;
 
 
@@ -30,7 +28,6 @@ public final class AmazonQViewContainer extends ViewPart implements EventObserve
     private Map<AmazonQViewType, BaseAmazonQView> views;
     private AmazonQViewType activeViewType;
     private BaseAmazonQView currentView;
-    private Disposable activeViewTypeSubscription;
     private final ReentrantLock containerLock;
 
     public AmazonQViewContainer() {
@@ -61,12 +58,7 @@ public final class AmazonQViewContainer extends ViewPart implements EventObserve
 
         parentComposite = parent;
 
-        setupStaticMenuActions();
         updateChildView();
-    }
-
-    private void setupStaticMenuActions() {
-        new AmazonQStaticActions(getViewSite());
     }
 
     private void updateChildView() {
@@ -86,10 +78,7 @@ public final class AmazonQViewContainer extends ViewPart implements EventObserve
                     currentView.dispose();
                 }
 
-                if (activeViewType == AmazonQViewType.CHAT_VIEW
-                        || activeViewType == AmazonQViewType.TOOLKIT_LOGIN_VIEW) {
-                    ((AmazonQView) newView).setViewSite(getViewSite());
-                }
+                newView.setViewSite(getViewSite());
 
                 Composite newViewComposite = newView.setupView(parentComposite);
                 GridData gridData = new GridData(SWT.CENTER, SWT.CENTER, true, true);

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/BaseAmazonQView.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/BaseAmazonQView.java
@@ -130,8 +130,8 @@ public abstract class BaseAmazonQView {
             signOutActionAuthStateSubscription = null;
         }
         if (feedbackDialogAuthStateSubscription != null && !feedbackDialogAuthStateSubscription.isDisposed()) {
-            signOutActionAuthStateSubscription.dispose();
-            signOutActionAuthStateSubscription = null;
+            feedbackDialogAuthStateSubscription.dispose();
+            feedbackDialogAuthStateSubscription = null;
         }
         if (customizationDialogAuthStateSubscription != null
                 && !customizationDialogAuthStateSubscription.isDisposed()) {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/BaseAmazonQView.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/BaseAmazonQView.java
@@ -57,7 +57,6 @@ public abstract class BaseAmazonQView {
 
         amazonQStaticActions = new AmazonQStaticActions(viewSite);
         viewSite.getActionBars().updateActionBars();
-
     }
 
     protected final AmazonQCommonActions getAmazonQCommonActions() {
@@ -129,15 +128,18 @@ public abstract class BaseAmazonQView {
             signOutActionAuthStateSubscription.dispose();
             signOutActionAuthStateSubscription = null;
         }
+
         if (feedbackDialogAuthStateSubscription != null && !feedbackDialogAuthStateSubscription.isDisposed()) {
             feedbackDialogAuthStateSubscription.dispose();
             feedbackDialogAuthStateSubscription = null;
         }
+
         if (customizationDialogAuthStateSubscription != null
                 && !customizationDialogAuthStateSubscription.isDisposed()) {
             customizationDialogAuthStateSubscription.dispose();
             customizationDialogAuthStateSubscription = null;
         }
+
         if (toggleAutoTriggerAuthStateSubscription != null && !toggleAutoTriggerAuthStateSubscription.isDisposed()) {
             toggleAutoTriggerAuthStateSubscription.dispose();
             toggleAutoTriggerAuthStateSubscription = null;

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/BaseAmazonQView.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/BaseAmazonQView.java
@@ -11,13 +11,58 @@ import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IViewSite;
 
+import io.reactivex.rxjava3.disposables.Disposable;
+import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.AuthState;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
 import software.aws.toolkits.eclipse.amazonq.util.PluginUtils;
+import software.aws.toolkits.eclipse.amazonq.views.actions.AmazonQCommonActions;
+import software.aws.toolkits.eclipse.amazonq.views.actions.AmazonQStaticActions;
 
 public abstract class BaseAmazonQView {
+
+    private IViewSite viewSite;
+
+    private AmazonQCommonActions amazonQCommonActions;
+    private AmazonQStaticActions amazonQStaticActions;
+
+    private Disposable signOutActionAuthStateSubscription;
+    private Disposable feedbackDialogAuthStateSubscription;
+    private Disposable customizationDialogAuthStateSubscription;
+    private Disposable toggleAutoTriggerAuthStateSubscription;
+
     public abstract Composite setupView(Composite parentComposite);
-    public abstract void dispose();
+
+    public final void setViewSite(final IViewSite viewSite) {
+        this.viewSite = viewSite;
+    }
+
+    protected final void setupAmazonQCommonActions() {
+        if (viewSite == null) {
+            Activator.getLogger().info("View Site is null for creating AmazonQCommonActions");
+            return;
+        }
+
+        amazonQCommonActions = new AmazonQCommonActions(viewSite);
+        setupCommonActionAuthListeners();
+        viewSite.getActionBars().updateActionBars();
+    }
+
+    protected final void setupAmazonQStaticActions() {
+        if (viewSite == null) {
+            Activator.getLogger().info("View Site is null for creating AmazonQStaticActions");
+            return;
+        }
+
+        amazonQStaticActions = new AmazonQStaticActions(viewSite);
+        viewSite.getActionBars().updateActionBars();
+
+    }
+
+    protected final AmazonQCommonActions getAmazonQCommonActions() {
+        return amazonQCommonActions;
+    }
 
     protected final Image loadImage(final String imagePath) {
         Image loadedImage = null;
@@ -40,4 +85,50 @@ public abstract class BaseAmazonQView {
         Font magnifiedFont = new Font(parentComposite.getDisplay(), fontData);
         return magnifiedFont;
     }
+
+    private void setupCommonActionAuthListeners() {
+        signOutActionAuthStateSubscription = Activator.getEventBroker().subscribe(AuthState.class,
+                amazonQCommonActions.getSignoutAction());
+        feedbackDialogAuthStateSubscription = Activator.getEventBroker().subscribe(AuthState.class,
+                amazonQCommonActions.getFeedbackDialogContributionAction());
+        customizationDialogAuthStateSubscription = Activator.getEventBroker().subscribe(AuthState.class,
+                amazonQCommonActions.getCustomizationDialogContributionAction());
+        toggleAutoTriggerAuthStateSubscription = Activator.getEventBroker().subscribe(AuthState.class,
+                amazonQCommonActions.getToggleAutoTriggerContributionAction());
+    }
+
+    /**
+     * Disposes of resources and cleans up subscriptions when the view is closed.
+     * This method ensures proper cleanup of authentication state subscriptions to prevent memory leaks.
+     *
+     * The following subscriptions are disposed:
+     * - Sign out action authentication state
+     * - Feedback dialog authentication state
+     * - Customization dialog authentication state
+     * - Auto-trigger toggle authentication state
+     *
+     * Each subscription is checked for null and disposal state before being disposed
+     * to prevent potential null pointer exceptions.
+     */
+    public void dispose() {
+        if (signOutActionAuthStateSubscription != null && !signOutActionAuthStateSubscription.isDisposed()) {
+            signOutActionAuthStateSubscription.dispose();
+        }
+        if (feedbackDialogAuthStateSubscription != null && !feedbackDialogAuthStateSubscription.isDisposed()) {
+            feedbackDialogAuthStateSubscription.dispose();
+        }
+        if (customizationDialogAuthStateSubscription != null
+                && !customizationDialogAuthStateSubscription.isDisposed()) {
+            customizationDialogAuthStateSubscription.dispose();
+        }
+        if (toggleAutoTriggerAuthStateSubscription != null && !toggleAutoTriggerAuthStateSubscription.isDisposed()) {
+            toggleAutoTriggerAuthStateSubscription.dispose();
+        }
+
+        if (amazonQCommonActions != null) {
+            amazonQCommonActions.dispose();
+            amazonQCommonActions = null;
+        }
+    }
+
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/BaseAmazonQView.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/BaseAmazonQView.java
@@ -64,6 +64,10 @@ public abstract class BaseAmazonQView {
         return amazonQCommonActions;
     }
 
+    protected final AmazonQStaticActions getAmazonQStaticActions() {
+        return amazonQStaticActions;
+    }
+
     protected final Image loadImage(final String imagePath) {
         Image loadedImage = null;
         try {
@@ -111,23 +115,32 @@ public abstract class BaseAmazonQView {
      * to prevent potential null pointer exceptions.
      */
     public void dispose() {
+        if (amazonQCommonActions != null) {
+            amazonQCommonActions.dispose();
+            amazonQCommonActions = null;
+        }
+
+        if (amazonQStaticActions != null) {
+            amazonQStaticActions.dispose();
+            amazonQStaticActions = null;
+        }
+
         if (signOutActionAuthStateSubscription != null && !signOutActionAuthStateSubscription.isDisposed()) {
             signOutActionAuthStateSubscription.dispose();
+            signOutActionAuthStateSubscription = null;
         }
         if (feedbackDialogAuthStateSubscription != null && !feedbackDialogAuthStateSubscription.isDisposed()) {
-            feedbackDialogAuthStateSubscription.dispose();
+            signOutActionAuthStateSubscription.dispose();
+            signOutActionAuthStateSubscription = null;
         }
         if (customizationDialogAuthStateSubscription != null
                 && !customizationDialogAuthStateSubscription.isDisposed()) {
             customizationDialogAuthStateSubscription.dispose();
+            customizationDialogAuthStateSubscription = null;
         }
         if (toggleAutoTriggerAuthStateSubscription != null && !toggleAutoTriggerAuthStateSubscription.isDisposed()) {
             toggleAutoTriggerAuthStateSubscription.dispose();
-        }
-
-        if (amazonQCommonActions != null) {
-            amazonQCommonActions.dispose();
-            amazonQCommonActions = null;
+            toggleAutoTriggerAuthStateSubscription = null;
         }
     }
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/CallToActionView.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/CallToActionView.java
@@ -62,6 +62,8 @@ public abstract class CallToActionView extends BaseAmazonQView {
         setupButton(container);
         setupButtonFooterContent(container);
 
+        setupAmazonQStaticActions();
+
         return container;
     }
 
@@ -85,8 +87,8 @@ public abstract class CallToActionView extends BaseAmazonQView {
     }
 
     @Override
-    public void dispose() {
-        // Default implementation - subclasses can override if they need to dispose of resources
+    public final void dispose() {
+        super.dispose();
     }
 
     protected abstract String getIconPath();

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/ChatAssetMissingView.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/ChatAssetMissingView.java
@@ -9,7 +9,6 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
-import software.aws.toolkits.eclipse.amazonq.util.ChatAssetProvider;
 
 public final class ChatAssetMissingView extends BaseAmazonQView {
     public static final String ID = "software.aws.toolkits.eclipse.amazonq.views.ChatAssetMissingView";
@@ -17,13 +16,8 @@ public final class ChatAssetMissingView extends BaseAmazonQView {
     private static final String ICON_PATH = "icons/AmazonQ64.png";
     private static final String HEADER_LABEL = "Error loading Q chat.";
     private static final String DETAIL_MESSAGE = "Restart Eclipse or review error logs for troubleshooting";
-    private ChatAssetProvider chatAssetProvider;
     private Image icon;
     private Composite container;
-
-    public ChatAssetMissingView() {
-        this.chatAssetProvider = new ChatAssetProvider();
-    }
 
     @Override
     public Composite setupView(final Composite parentComposite) {
@@ -62,14 +56,13 @@ public final class ChatAssetMissingView extends BaseAmazonQView {
         detailLabel.setText(DETAIL_MESSAGE);
         detailLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 
+        setupAmazonQStaticActions();
+
         return container;
     }
 
     @Override
     public void dispose() {
-        if (chatAssetProvider != null) {
-            chatAssetProvider.dispose();
-            chatAssetProvider = null;
-        }
+        super.dispose();
     }
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/DependencyMissingView.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/DependencyMissingView.java
@@ -72,7 +72,6 @@ public final class DependencyMissingView extends CallToActionView {
 
     private String getInstallUrl() {
         return platform == PluginPlatform.WINDOWS ? EDGE_INSTALL : WEBKIT_INSTALL;
-
     }
 
     private String getLearnMoreUrl() {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/LspStartUpFailedView.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/LspStartUpFailedView.java
@@ -21,10 +21,6 @@ public final class LspStartUpFailedView extends BaseAmazonQView {
     private Image icon;
     private Composite container;
 
-    public LspStartUpFailedView() {
-        //
-    }
-
     @Override
     public Composite setupView(final Composite parentComposite) {
         container = new Composite(parentComposite, SWT.NONE);
@@ -61,6 +57,8 @@ public final class LspStartUpFailedView extends BaseAmazonQView {
         Label detailLabel = new Label(container, SWT.CENTER | SWT.WRAP);
         detailLabel.setText(DETAIL_MESSAGE);
         detailLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+
+        setupAmazonQStaticActions();
 
         return container;
     }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/LspStartUpFailedView.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/LspStartUpFailedView.java
@@ -65,7 +65,7 @@ public final class LspStartUpFailedView extends BaseAmazonQView {
 
     @Override
     public void dispose() {
-        //default implementation
+        super.dispose();
     }
 
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/ToolkitLoginWebview.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/ToolkitLoginWebview.java
@@ -90,6 +90,8 @@ public final class ToolkitLoginWebview extends AmazonQView {
 
         browser.setText(content.get());
 
+        setupAmazonQStaticActions();
+
         return parent;
     }
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/ToolkitLoginWebview.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/ToolkitLoginWebview.java
@@ -90,7 +90,7 @@ public final class ToolkitLoginWebview extends AmazonQView {
 
         browser.setText(content.get());
 
-        setupAmazonQStaticActions();
+        setupAmazonQCommonActions();
 
         return parent;
     }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/AmazonQCommonActions.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/AmazonQCommonActions.java
@@ -22,7 +22,7 @@ public final class AmazonQCommonActions {
     private ViewLogsAction viewLogsAction;
     private ReportAnIssueAction reportAnIssueAction;
 
-    private IActionBars bars;
+    private IMenuManager menuManager;
 
     public AmazonQCommonActions(final IViewSite viewSite) {
         createActions(viewSite);
@@ -59,18 +59,18 @@ public final class AmazonQCommonActions {
 
     private void contributeToActionBars(final IViewSite viewSite) {
         IActionBars bars = viewSite.getActionBars();
-        IMenuManager menuManager = bars.getMenuManager();
+        menuManager = bars.getMenuManager();
         IToolBarManager toolBarManager = bars.getToolBarManager();
 
         menuManager.removeAll();
         toolBarManager.removeAll();
         bars.updateActionBars();
 
-        fillLocalPullDown(menuManager);
+        fillLocalPullDown();
         fillLocalToolBar(toolBarManager);
     }
 
-    private void fillLocalPullDown(final IMenuManager manager) {
+    private void fillLocalPullDown() {
         IMenuManager feedbackSubMenu = new MenuManager("Feedback");
         feedbackSubMenu.add(reportAnIssueAction);
         feedbackSubMenu.add(feedbackDialogContributionItem.getDialogContributionItem());
@@ -81,19 +81,31 @@ public final class AmazonQCommonActions {
         helpSubMenu.add(viewSourceAction);
         helpSubMenu.add(viewLogsAction);
 
-        manager.add(openCodeReferenceLogAction);
-        manager.add(new Separator());
-        manager.add(toggleAutoTriggerContributionItem);
-        manager.add(customizationDialogContributionItem);
-        manager.add(new Separator());
-        manager.add(feedbackSubMenu);
-        manager.add(helpSubMenu);
-        manager.add(new Separator());
-        manager.add(signoutAction);
+        menuManager.add(openCodeReferenceLogAction);
+        menuManager.add(new Separator());
+        menuManager.add(toggleAutoTriggerContributionItem);
+        menuManager.add(customizationDialogContributionItem);
+        menuManager.add(new Separator());
+        menuManager.add(feedbackSubMenu);
+        menuManager.add(helpSubMenu);
+        menuManager.add(new Separator());
+        menuManager.add(signoutAction);
     }
 
     private void fillLocalToolBar(final IToolBarManager manager) {
         // No actions added to the view toolbar at this time
+    }
+
+    public void dispose() {
+        if (toggleAutoTriggerContributionItem != null) {
+            toggleAutoTriggerContributionItem.dispose();
+            toggleAutoTriggerContributionItem = null;
+        }
+
+        if (menuManager != null) {
+            menuManager.dispose();
+            menuManager = null;
+        }
     }
 
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/AmazonQStaticActions.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/AmazonQStaticActions.java
@@ -15,6 +15,8 @@ public final class AmazonQStaticActions {
     private ViewLogsAction viewLogsAction;
     private ReportAnIssueAction reportAnIssueAction;
 
+    private IMenuManager menuManager;
+
     public AmazonQStaticActions(final IViewSite viewSite) {
         createActions(viewSite);
         contributeToActionBars(viewSite);
@@ -29,10 +31,11 @@ public final class AmazonQStaticActions {
 
     private void contributeToActionBars(final IViewSite viewSite) {
         IActionBars bars = viewSite.getActionBars();
-        fillLocalPullDown(bars.getMenuManager());
+        menuManager = bars.getMenuManager();
+        fillLocalPullDown();
     }
 
-    private void fillLocalPullDown(final IMenuManager manager) {
+    private void fillLocalPullDown() {
         IMenuManager feedbackSubMenu = new MenuManager("Feedback");
         feedbackSubMenu.add(reportAnIssueAction);
 
@@ -42,8 +45,15 @@ public final class AmazonQStaticActions {
         helpSubMenu.add(viewSourceAction);
         helpSubMenu.add(viewLogsAction);
 
-        manager.add(feedbackSubMenu);
-        manager.add(helpSubMenu);
+        menuManager.add(feedbackSubMenu);
+        menuManager.add(helpSubMenu);
+    }
+
+    public void dispose() {
+        if (menuManager != null) {
+            menuManager.dispose();
+            menuManager = null;
+        }
     }
 
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/ToggleAutoTriggerContributionItem.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/ToggleAutoTriggerContributionItem.java
@@ -79,8 +79,16 @@ public final class ToggleAutoTriggerContributionItem extends ContributionItem im
 
     @Override
     public void dispose() {
-        pause.dispose();
-        resume.dispose();
+        if (pause != null) {
+            pause.dispose();
+            pause = null;
+        }
+
+        if (resume != null) {
+            resume.dispose();
+            resume = null;
+        }
+
         super.dispose();
     }
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/router/ViewRouter.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/router/ViewRouter.java
@@ -104,7 +104,7 @@ public final class ViewRouter implements EventObserver<PluginState> {
 
         if (pluginState.browserCompatibilityState() == BrowserCompatibilityState.DEPENDENCY_MISSING) {
             newActiveView = AmazonQViewType.DEPENDENCY_MISSING_VIEW;
-        } else if (pluginState.lspState().hasFailed()) {
+        } else if (pluginState.lspState() == LspState.FAILED) {
             newActiveView = AmazonQViewType.LSP_STARTUP_FAILED_VIEW;
         } else if (pluginState.chatWebViewAssetState() == ChatWebViewAssetState.DEPENDENCY_MISSING
                 || pluginState.toolkitLoginWebViewAssetState() == ToolkitLoginWebViewAssetState.DEPENDENCY_MISSING) {


### PR DESCRIPTION
*Issue #314*

*Description of changes:*
- Refactor views to setup and dispose different actions implicitly.
- BaseAmazonQView provides the functionality to setup either static actions (for view other than than the browser based views) or setup common actions (for AmazonQChatWebView and ToolkitLoginWebview).
- The views handle which type of action they create.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
