### PR TITLE
Fix mynah UI progress indicator

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
@@ -268,7 +268,8 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
                                     postMessage: (message) => {
                                         ideCommand(JSON.stringify(message));
                                     }
-                                }, {
+                                },
+                                {
                                     quickActionCommands: %s,
                                     disclaimerAcknowledged: %b
                                 });
@@ -284,10 +285,12 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
 
                     %s
 
+                    %s
+
                 </script>
                 """, jsEntrypoint, getWaitFunction(), chatQuickActionConfig,
                 "true".equals(disclaimerAcknowledged), getArrowKeyBlockingFunction(),
-                getSelectAllAndCopySupportFunctions(), getPreventEmptyPopupFunction());
+                getSelectAllAndCopySupportFunctions(), getPreventEmptyPopupFunction(), getFocusOnChatPromptFunction());
     }
 
     /*
@@ -421,6 +424,21 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
                     console.error('Error starting observer:', error);
                 }
                 """.formatted(selector);
+    }
+
+    private String getFocusOnChatPromptFunction() {
+        return """
+                window.addEventListener('load', () => {
+                    const chatContainer = document.querySelector('.mynah-chat-prompt');
+                    if (chatContainer) {
+                        chatContainer.addEventListener('click', (event) => {
+                            if (!event.target.closest('.mynah-chat-prompt-input')) {
+                                keepFocusOnPrompt();
+                            }
+                        });
+                    }
+                });
+                """;
     }
 
     @Override

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
@@ -250,6 +250,9 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
                     textarea:placeholder-shown {
                         line-height: 1.5rem;
                     }
+                    .mynah-ui-spinner-container > span.mynah-ui-spinner-logo-part > .mynah-ui-spinner-logo-mask.text {
+                        opacity: 1 !important;
+                    }
                 </style>
                 """;
     }


### PR DESCRIPTION
*Issue #345*

*Description of changes:*
- Fix MynahUI progress indicator not disappearing after chat result has streamed.
- Transfer focus to chat prompt after result has streamed, which is a condition that causes the progress indicator to disappear.
- This isn't an airtight fix, but it significantly reduces the stale left-over progress bar appearances.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
