### PR TITLE
Redirect old views to point to the ViewContainer

### DIFF
--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -6,6 +6,138 @@
 	      <variable name="is_logged_in" priorityLevel="workbench"/>
 	   </sourceProvider>
 	</extension>
+	    <extension
+        point="org.eclipse.ui.views">
+        <!-- If adding a new view: -->
+        <!-- 1. Include the view in the activities extension point to hide it from the Show View menu -->
+        <!-- 2. Include the view in the perspectiveExtensions extension point to display it in the appropriate part of the layout -->
+        <category
+            name="Amazon Q"
+            id="amazonq">
+        </category>
+        <view
+            id="software.aws.toolkits.eclipse.amazonq.views.ReauthenticateView"
+            name="Amazon Q"
+            icon="icons/AmazonQ.png"
+            class="software.aws.toolkits.eclipse.amazonq.views.AmazonQViewContainer">
+        </view>
+        <view
+            id="software.aws.toolkits.eclipse.amazonq.views.DependencyMissingView"
+            name="Amazon Q"
+            icon="icons/AmazonQ.png"
+            class="software.aws.toolkits.eclipse.amazonq.views.AmazonQViewContainer">
+        </view>
+        <view
+            id="software.aws.toolkits.eclipse.amazonq.views.ChatAssetMissingView"
+            name="Amazon Q"
+            icon="icons/AmazonQ.png"
+            class="software.aws.toolkits.eclipse.amazonq.views.AmazonQViewContainer">
+        </view>
+        <view
+            id="software.aws.toolkits.eclipse.amazonq.views.ToolkitLoginWebview"
+            name="Amazon Q"
+            icon="icons/AmazonQ.png"
+            class="software.aws.toolkits.eclipse.amazonq.views.AmazonQViewContainer"
+            category="amazonq"
+            inject="true">
+        </view>
+        <view
+            id="software.aws.toolkits.eclipse.amazonq.views.AmazonQChatWebview"
+            name="Amazon Q"
+            icon="icons/AmazonQ.png"
+            class="software.aws.toolkits.eclipse.amazonq.views.AmazonQViewContainer"
+            inject="true">
+        </view>
+   </extension>
+    <extension point="org.eclipse.ui.activities">  
+      <!-- These activities and activityPatternBindings prevent the view from showing up in the Show View menu. Logic exists that will filter these views out. -->
+      <!-- ToolkitLoginWebview is intentionally excluded here as this should be the only view that should show in the menu. -->
+	  <activity id="software.aws.toolkits.eclipse.amazonq.activity.AmazonQChatWebview" name="Amazon Q Chat">
+	  </activity>
+	  <activity id="software.aws.toolkits.eclipse.amazonq.activity.AmazonQCodeReferenceView" name="Amazon Q Code Reference">
+	  </activity>
+	  <activity id="software.aws.toolkits.eclipse.amazonq.activity.DependencyMissingView" name="Amazon Q Dependency Missing">
+	  </activity>
+	  <activity id="software.aws.toolkits.eclipse.amazonq.activity.ReauthenticateView" name="Amazon Q Reauthenticate">
+	  </activity>
+      <activity id="software.aws.toolkits.eclipse.amazonq.activity.ChatAssetMissingView" name="Amazon Q Chat Missing">
+	  </activity>
+	  <activityPatternBinding
+	     activityId="software.aws.toolkits.eclipse.amazonq.activity.AmazonQChatWebview"
+	     isEqualityPattern="true"
+	     pattern="amazon-q-eclipse/software.aws.toolkits.eclipse.amazonq.views.AmazonQChatWebview">
+	  </activityPatternBinding>
+	  <activityPatternBinding
+	     activityId="software.aws.toolkits.eclipse.amazonq.activity.AmazonQCodeReferenceView"
+	     isEqualityPattern="true"
+	     pattern="amazon-q-eclipse/software.aws.toolkits.eclipse.amazonq.views.AmazonQCodeReferenceView">
+	  </activityPatternBinding>
+	  <activityPatternBinding
+	     activityId="software.aws.toolkits.eclipse.amazonq.activity.DependencyMissingView"
+	     isEqualityPattern="true"
+	     pattern="amazon-q-eclipse/software.aws.toolkits.eclipse.amazonq.views.DependencyMissingView">
+	  </activityPatternBinding>
+	  <activityPatternBinding
+	     activityId="software.aws.toolkits.eclipse.amazonq.activity.ReauthenticateView"
+	     isEqualityPattern="true"
+	     pattern="amazon-q-eclipse/software.aws.toolkits.eclipse.amazonq.views.ReauthenticateView">
+	  </activityPatternBinding>
+        <activityPatternBinding
+	     activityId="software.aws.toolkits.eclipse.amazonq.activity.ChatAssetMissingView"
+	     isEqualityPattern="true"
+	     pattern="amazon-q-eclipse/software.aws.toolkits.eclipse.amazonq.views.ChatAssetMissingView">
+	  </activityPatternBinding>
+	 </extension>
+    <extension
+        point="org.eclipse.ui.perspectiveExtensions">
+        <!-- These perspectiveExtensions ensure that the view is display in the appropriate portion of the layout. In most cases, it should stack the ToolkitLoginWebview. -->
+        <perspectiveExtension
+            targetID="*">
+            <view
+                id="software.aws.toolkits.eclipse.amazonq.views.ToolkitLoginWebview"
+                relative="org.eclipse.ui.editorss"
+                relationship="right"
+                visible="false">
+            </view>
+            <view
+                id="software.aws.toolkits.eclipse.amazonq.views.AmazonQChatWebview"
+                relative="software.aws.toolkits.eclipse.amazonq.views.ToolkitLoginWebview"
+                relationship="stack"
+                visible="false">
+            </view>
+            <view
+                id="software.aws.toolkits.eclipse.amazonq.views.AmazonQCodeReferenceView"
+                relative="software.aws.toolkits.eclipse.amazonq.views.ToolkitLoginWebview"
+                relationship="stack"
+                visible="false">
+            </view>
+            <view
+                id="software.aws.toolkits.eclipse.amazonq.views.DependencyMissingView"
+                relative="software.aws.toolkits.eclipse.amazonq.views.ToolkitLoginWebview"
+                relationship="stack"
+                visible="false">
+            </view>
+            <view
+                id="software.aws.toolkits.eclipse.amazonq.views.ReauthenticateView"
+                relative="software.aws.toolkits.eclipse.amazonq.views.ToolkitLoginWebview"
+                relationship="stack"
+                visible="false">
+            </view>
+            <view
+                id="software.aws.toolkits.eclipse.amazonq.views.DependencyMissingView"
+                relative="software.aws.toolkits.eclipse.amazonq.views.ToolkitLoginWebview"
+                relationship="stack"
+                visible="false">
+            </view>
+             <view
+                id="software.aws.toolkits.eclipse.amazonq.views.ChatAssetMissingView"
+                relative="software.aws.toolkits.eclipse.amazonq.views.ToolkitLoginWebview"
+                relationship="stack"
+                visible="false">
+            </view>
+        </perspectiveExtension>
+    </extension>
+	
     <extension
         point="org.eclipse.ui.views">
         <!-- If adding a new view: -->

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -8,9 +8,7 @@
 	</extension>
 	    <extension
         point="org.eclipse.ui.views">
-        <!-- If adding a new view: -->
-        <!-- 1. Include the view in the activities extension point to hide it from the Show View menu -->
-        <!-- 2. Include the view in the perspectiveExtensions extension point to display it in the appropriate part of the layout -->
+        <!-- Old View Ids registered necessary to migrate to ViewContainer -->
         <category
             name="Amazon Q"
             id="amazonq">


### PR DESCRIPTION
*Issue #314*

*Description of changes:*
- Redirect old view IDs to point to the new ViewContainer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
