### PR TITLE
Fix build path issues due to conflict with Tycho and OSGI builds

### DIFF
--- a/plugin/build.properties
+++ b/plugin/build.properties
@@ -3,7 +3,6 @@ output.. = target/classes
 bin.includes = plugin.xml,\
                META-INF/,\
                icons/,\
-               target/classes/,\
                webview/build/,\
                target/dependency/,\
                codegen-resources/

--- a/plugin/build/syncDependencies.sh
+++ b/plugin/build/syncDependencies.sh
@@ -19,7 +19,7 @@ if [ ! -f "$manifest_file" ]; then
 fi
 
 # Initialize the Bundle-Classpath entry
-bundle_classpath="Bundle-Classpath: target/classes/,\n"
+bundle_classpath="Bundle-Classpath: .,\n"
 
 # Loop through the JAR files in the dependency directory
 for jar in "$dependency_dir"/*.jar; do

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -17,7 +17,7 @@
         <aws.java.sdk.version>2.28.26</aws.java.sdk.version>
         <node.version>v20.9.0</node.version>
         <npm.version>10.1.0</npm.version>
-        <jackson.version>2.17.2</jackson.version>
+        <jackson.version>2.17.3</jackson.version>
         <maven.compiler.release>17</maven.compiler.release>
         <junit.version>5.11.3</junit.version>
     </properties>
@@ -135,6 +135,21 @@
                 <version>${tycho.version}</version>
                 <configuration>
                     <pomDependencies>consider</pomDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-packaging-plugin</artifactId>
+                <version>${tycho.version}</version>
+                <configuration>
+                    <additionalFileSets>
+                     <fileSet>
+                      <directory>${project.build.directory}/classes/</directory>
+                      <includes>
+                       <include>**/*</include>
+                      </includes>
+                     </fileSet>
+                    </additionalFileSets>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <tycho.version>4.0.8</tycho.version>
+        <tycho.version>4.0.11</tycho.version>
         <maven.resource.version>3.3.1</maven.resource.version>
     </properties>
 


### PR DESCRIPTION
*Description of changes:*
Removes an explicit `bin.includes` entry for `target/classes` and instead uses the Tycho packaging plugin to include build classes at the root of the JAR. The classpath entry in `META-INF/MANIFEST.MF` now includes the root dir as a classpath root.

This will make Eclipse happy while developing in the IDE while meanwhile ensuring that built classes are included correctly in the Tycho produced JAR. It likely does break the ability to export a plugin JAR from the Eclipse IDE directly, but I do not believe this to be of major concern since they can and should be produced via Maven build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
