### PR TITLE
Add dropdown menu on top level Q toolbar icon

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup Maven Action
-      uses: s4u/setup-maven-action@v1.14.0
+      uses: s4u/setup-maven-action@v1.18.0
       with:
         checkout-fetch-depth: 0
         java-version: 17

--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -27,7 +27,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.31.0",
  org.eclipse.core.net;bundle-version="1.5.400",
  org.apache.commons.logging;bundle-version="1.2.0",
  slf4j.api;bundle-version="2.0.13",
- org.apache.commons.lang3;bundle-version="3.14.0"
+ org.apache.commons.lang3;bundle-version="3.14.0",
+ org.eclipse.core.expressions;bundle-version="3.9.400"
 Bundle-Classpath: .,
  target/dependency/annotations.jar,
  target/dependency/apache-client.jar,

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -347,6 +347,7 @@
                 <command id="software.aws.toolkits.eclipse.amazonq.toolbar.command"
                     commandId="software.aws.toolkits.eclipse.amazonq.commands.openAmazonQLoginView"
                     icon="icons/AmazonQ.png"
+                    style="pulldown"
                     tooltip="Amazon Q">
                     <visibleWhen checkEnabled="false">
                         <with variable="is_logged_in"> <!-- Provided by AuthSourceProvider  -->

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -121,7 +121,9 @@
 
     <build>
         <sourceDirectory>src</sourceDirectory>
+        <outputDirectory>target/classes</outputDirectory>
         <testSourceDirectory>tst</testSourceDirectory>
+        <testOutputDirectory>target/test-classes</testOutputDirectory>
         <plugins>
             <plugin>
                 <groupId>org.eclipse.tycho</groupId>

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/CustomizationDialog.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/CustomizationDialog.java
@@ -183,11 +183,7 @@ public final class CustomizationDialog extends Dialog {
         for (int index = 0; index < customizations.size(); index++) {
             addFormattedOption(combo, customizations.get(index).getName(), customizations.get(index).getDescription());
             combo.setData(String.format("%s", index), customizations.get(index));
-            if (this.responseSelection.equals(ResponseSelection.CUSTOMIZATION)
-                    && Objects.nonNull(this.getSelectedCustomization())
-                    && this.getSelectedCustomization().getArn().equals(customizations.get(index).getArn())) {
-                defaultSelectedDropdownIndex = index;
-            }
+            defaultSelectedDropdownIndex = index;
         }
         combo.select(defaultSelectedDropdownIndex);
         if (this.responseSelection.equals(ResponseSelection.AMAZON_Q_FOUNDATION_DEFAULT) || customizations.isEmpty()) {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/AmazonQCommonActions.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/AmazonQCommonActions.java
@@ -2,99 +2,125 @@
 
 package software.aws.toolkits.eclipse.amazonq.views.actions;
 
+import org.eclipse.jface.action.IContributionItem;
 import org.eclipse.jface.action.IMenuManager;
-import org.eclipse.jface.action.IToolBarManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.action.Separator;
-import org.eclipse.ui.IActionBars;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IViewSite;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.menus.AbstractContributionFactory;
+import org.eclipse.ui.menus.IMenuService;
 
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.AuthState;
 
-
 public final class AmazonQCommonActions {
+    private final Actions actions;
+    private AbstractContributionFactory factory;
 
-    private SignoutAction signoutAction;
-    private FeedbackDialogContributionItem feedbackDialogContributionItem;
-    private CustomizationDialogContributionItem customizationDialogContributionItem;
-    private ToggleAutoTriggerContributionItem toggleAutoTriggerContributionItem;
-    private OpenCodeReferenceLogAction openCodeReferenceLogAction;
-    private OpenUserGuideAction openUserGuideAction;
-    private ViewSourceAction viewSourceAction;
-    private ViewLogsAction viewLogsAction;
-    private ReportAnIssueAction reportAnIssueAction;
+    private static class Actions {
+        final SignoutAction signoutAction;
+        final FeedbackDialogContributionItem feedbackDialogContributionItem;
+        final CustomizationDialogContributionItem customizationDialogContributionItem;
+        final ToggleAutoTriggerContributionItem toggleAutoTriggerContributionItem;
+        final OpenCodeReferenceLogAction openCodeReferenceLogAction;
+        final OpenUserGuideAction openUserGuideAction;
+        final ViewSourceAction viewSourceAction;
+        final ViewLogsAction viewLogsAction;
+        final ReportAnIssueAction reportAnIssueAction;
+
+        Actions(IViewSite viewSite) {
+            signoutAction = new SignoutAction();
+            feedbackDialogContributionItem = new FeedbackDialogContributionItem();
+            customizationDialogContributionItem = new CustomizationDialogContributionItem();
+            toggleAutoTriggerContributionItem = new ToggleAutoTriggerContributionItem();
+            openCodeReferenceLogAction = new OpenCodeReferenceLogAction();
+            openUserGuideAction = new OpenUserGuideAction();
+            viewSourceAction = new ViewSourceAction();
+            viewLogsAction = new ViewLogsAction();
+            reportAnIssueAction = new ReportAnIssueAction();
+        }
+    }
 
     public AmazonQCommonActions(final AuthState authState, final IViewSite viewSite) {
-        createActions(viewSite);
-        contributeToActionBars(viewSite);
+        actions = new Actions(viewSite);
+        fillLocalPullDown(viewSite.getActionBars().getMenuManager());
         updateActionVisibility(authState, viewSite);
     }
 
     public SignoutAction getSignoutAction() {
-        return signoutAction;
+        return actions.signoutAction;
     }
 
     public FeedbackDialogContributionItem getFeedbackDialogContributionAction() {
-        return feedbackDialogContributionItem;
+        return actions.feedbackDialogContributionItem;
     }
 
     public CustomizationDialogContributionItem getCustomizationDialogContributionAction() {
-        return customizationDialogContributionItem;
+        return actions.customizationDialogContributionItem;
     }
 
     public ToggleAutoTriggerContributionItem getToggleAutoTriggerContributionAction() {
-        return toggleAutoTriggerContributionItem;
-    }
-
-    private void createActions(final IViewSite viewSite) {
-        signoutAction = new SignoutAction();
-        feedbackDialogContributionItem = new FeedbackDialogContributionItem(viewSite);
-        customizationDialogContributionItem = new CustomizationDialogContributionItem(viewSite);
-        toggleAutoTriggerContributionItem = new ToggleAutoTriggerContributionItem(viewSite);
-        openUserGuideAction = new OpenUserGuideAction();
-        viewSourceAction = new ViewSourceAction();
-        viewLogsAction = new ViewLogsAction();
-        reportAnIssueAction = new ReportAnIssueAction();
-        openCodeReferenceLogAction = new OpenCodeReferenceLogAction();
-    }
-
-    private void contributeToActionBars(final IViewSite viewSite) {
-        IActionBars bars = viewSite.getActionBars();
-        fillLocalPullDown(bars.getMenuManager());
-        fillLocalToolBar(bars.getToolBarManager());
+        return actions.toggleAutoTriggerContributionItem;
     }
 
     private void fillLocalPullDown(final IMenuManager manager) {
+        addCommonMenuItems(manager);
+    }
+
+    private void fillGlobalToolBar() {
+        final IMenuService menuService = (IMenuService) PlatformUI.getWorkbench().getService(IMenuService.class);
+        var contributionFactory = new MenuContributionFactory("software.aws.toolkits.eclipse.amazonq.toolbar.command");
+
+        IMenuManager tempManager = new MenuManager();
+        addCommonMenuItems(tempManager);
+
+        for (IContributionItem item : tempManager.getItems()) {
+            if (item.isVisible()) {
+                contributionFactory.addContributionItem(item);
+            }
+        }
+
+        menuService.addContributionFactory(contributionFactory);
+        this.factory = contributionFactory;
+    }
+
+    private void addCommonMenuItems(IMenuManager manager) {
         IMenuManager feedbackSubMenu = new MenuManager("Feedback");
-        feedbackSubMenu.add(reportAnIssueAction);
-        feedbackSubMenu.add(feedbackDialogContributionItem.getDialogContributionItem());
+        feedbackSubMenu.add(actions.reportAnIssueAction);
+        feedbackSubMenu.add(actions.feedbackDialogContributionItem.getDialogContributionItem());
 
         IMenuManager helpSubMenu = new MenuManager("Help");
-        helpSubMenu.add(openUserGuideAction);
+        helpSubMenu.add(actions.openUserGuideAction);
         helpSubMenu.add(new Separator());
-        helpSubMenu.add(viewSourceAction);
-        helpSubMenu.add(viewLogsAction);
+        helpSubMenu.add(actions.viewSourceAction);
+        helpSubMenu.add(actions.viewLogsAction);
 
-        manager.add(openCodeReferenceLogAction);
+        manager.add(actions.openCodeReferenceLogAction);
         manager.add(new Separator());
-        manager.add(toggleAutoTriggerContributionItem);
-        manager.add(customizationDialogContributionItem);
+        manager.add(actions.toggleAutoTriggerContributionItem);
+        manager.add(actions.customizationDialogContributionItem);
         manager.add(new Separator());
         manager.add(feedbackSubMenu);
         manager.add(helpSubMenu);
         manager.add(new Separator());
-        manager.add(signoutAction);
-    }
-
-    private void fillLocalToolBar(final IToolBarManager manager) {
-        // No actions added to the view toolbar at this time
+        manager.add(actions.signoutAction);
     }
 
     public void updateActionVisibility(final AuthState authState, final IViewSite viewSite) {
-        signoutAction.updateVisibility(authState);
-        feedbackDialogContributionItem.updateVisibility(authState);
-        customizationDialogContributionItem.updateVisibility(authState);
-        toggleAutoTriggerContributionItem.updateVisibility(authState);
-    }
+        actions.signoutAction.updateVisibility(authState);
+        actions.feedbackDialogContributionItem.updateVisibility(authState);
+        actions.customizationDialogContributionItem.updateVisibility(authState);
+        actions.toggleAutoTriggerContributionItem.updateVisibility(authState);
+        Display.getDefault().asyncExec(() -> {
+            viewSite.getActionBars().getMenuManager().markDirty();
+            viewSite.getActionBars().getMenuManager().update(true);
 
+            final IMenuService menuService = (IMenuService) PlatformUI.getWorkbench().getService(IMenuService.class);
+            if (factory != null) {
+                menuService.removeContributionFactory(factory);
+            }
+            fillGlobalToolBar();
+        });
+    }
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/AmazonQCommonActions.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/AmazonQCommonActions.java
@@ -19,22 +19,24 @@ public final class AmazonQCommonActions {
     private AbstractContributionFactory factory;
 
     private static class Actions {
-        final SignoutAction signoutAction;
-        final FeedbackDialogContributionItem feedbackDialogContributionItem;
-        final CustomizationDialogContributionItem customizationDialogContributionItem;
-        final ToggleAutoTriggerContributionItem toggleAutoTriggerContributionItem;
-        final OpenCodeReferenceLogAction openCodeReferenceLogAction;
-        final OpenUserGuideAction openUserGuideAction;
-        final ViewSourceAction viewSourceAction;
-        final ViewLogsAction viewLogsAction;
-        final ReportAnIssueAction reportAnIssueAction;
+        private final SignoutAction signoutAction;
+        private final FeedbackDialogContributionItem feedbackDialogContributionItem;
+        private final CustomizationDialogContributionItem customizationDialogContributionItem;
+        private final ToggleAutoTriggerContributionItem toggleAutoTriggerContributionItem;
+        private final OpenQChatAction openQChatAction;
+        private final OpenCodeReferenceLogAction openCodeReferenceLogAction;
+        private final OpenUserGuideAction openUserGuideAction;
+        private final ViewSourceAction viewSourceAction;
+        private final ViewLogsAction viewLogsAction;
+        private final ReportAnIssueAction reportAnIssueAction;
 
-        Actions(IViewSite viewSite) {
+        Actions(final IViewSite viewSite) {
             signoutAction = new SignoutAction();
             feedbackDialogContributionItem = new FeedbackDialogContributionItem();
             customizationDialogContributionItem = new CustomizationDialogContributionItem();
             toggleAutoTriggerContributionItem = new ToggleAutoTriggerContributionItem();
             openCodeReferenceLogAction = new OpenCodeReferenceLogAction();
+            openQChatAction = new OpenQChatAction();
             openUserGuideAction = new OpenUserGuideAction();
             viewSourceAction = new ViewSourceAction();
             viewLogsAction = new ViewLogsAction();
@@ -73,6 +75,7 @@ public final class AmazonQCommonActions {
         var contributionFactory = new MenuContributionFactory("software.aws.toolkits.eclipse.amazonq.toolbar.command");
 
         IMenuManager tempManager = new MenuManager();
+        tempManager.add(actions.openQChatAction);
         addCommonMenuItems(tempManager);
 
         for (IContributionItem item : tempManager.getItems()) {
@@ -85,7 +88,7 @@ public final class AmazonQCommonActions {
         this.factory = contributionFactory;
     }
 
-    private void addCommonMenuItems(IMenuManager manager) {
+    private void addCommonMenuItems(final IMenuManager manager) {
         IMenuManager feedbackSubMenu = new MenuManager("Feedback");
         feedbackSubMenu.add(actions.reportAnIssueAction);
         feedbackSubMenu.add(actions.feedbackDialogContributionItem.getDialogContributionItem());

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/CustomizationDialogContributionItem.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/CustomizationDialogContributionItem.java
@@ -9,11 +9,9 @@ import org.eclipse.jface.action.ContributionItem;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.IViewSite;
 
 import jakarta.inject.Inject;
 import software.aws.toolkits.eclipse.amazonq.broker.api.EventObserver;
@@ -31,19 +29,10 @@ public final class CustomizationDialogContributionItem extends ContributionItem 
 
     @Inject
     private Shell shell;
-    private IViewSite viewSite;
-
-    public CustomizationDialogContributionItem(final IViewSite viewSite) {
-        this.viewSite = viewSite;
-    }
 
     // TODO: Need to update this method as the login condition has to be Pro login using IAM identity center
     public void updateVisibility(final AuthState authState) {
         this.setVisible(authState.isLoggedIn() && authState.loginType().equals(LoginType.IAM_IDENTITY_CENTER));
-        Display.getDefault().asyncExec(() -> {
-            viewSite.getActionBars().getMenuManager().markDirty();
-            viewSite.getActionBars().getMenuManager().update(true);
-        });
     }
 
     @Override

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/FeedbackDialogContributionItem.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/FeedbackDialogContributionItem.java
@@ -1,8 +1,6 @@
 package software.aws.toolkits.eclipse.amazonq.views.actions;
 
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.IViewSite;
 
 import jakarta.inject.Inject;
 import software.aws.toolkits.eclipse.amazonq.broker.api.EventObserver;
@@ -15,12 +13,10 @@ public final class FeedbackDialogContributionItem implements EventObserver<AuthS
 
     @Inject
     private Shell shell;
-    private IViewSite viewSite;
 
     private DialogContributionItem feedbackDialogContributionItem;
 
-    public FeedbackDialogContributionItem(final IViewSite viewSite) {
-        this.viewSite = viewSite;
+    public FeedbackDialogContributionItem() {
         feedbackDialogContributionItem = new DialogContributionItem(
                 new FeedbackDialog(shell),
                 SHARE_FEEDBACK_MENU_ITEM_TEXT
@@ -29,10 +25,6 @@ public final class FeedbackDialogContributionItem implements EventObserver<AuthS
 
     public void updateVisibility(final AuthState authState) {
         feedbackDialogContributionItem.setVisible(authState.isLoggedIn());
-        Display.getDefault().asyncExec(() -> {
-            viewSite.getActionBars().getMenuManager().markDirty();
-            viewSite.getActionBars().getMenuManager().update(true);
-        });
     }
 
     public DialogContributionItem getDialogContributionItem() {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/MenuContributionFactory.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/MenuContributionFactory.java
@@ -12,24 +12,24 @@ import org.eclipse.ui.menus.AbstractContributionFactory;
 import org.eclipse.ui.menus.IContributionRoot;
 import org.eclipse.ui.services.IServiceLocator;
 
-public class MenuContributionFactory extends AbstractContributionFactory {
+public final class MenuContributionFactory extends AbstractContributionFactory {
 
     private List<IContributionItem> items = new ArrayList<>();
 
-    public MenuContributionFactory(String location) {
+    public MenuContributionFactory(final String location) {
         super("menu:" + location, null);
     }
 
-    public void addContributionItem(IContributionItem item) {
+    public void addContributionItem(final IContributionItem item) {
         items.add(item);
     }
 
-    public void addAction(IAction action) {
+    public void addAction(final IAction action) {
         items.add(new ActionContributionItem(action));
     }
 
     @Override
-    public void createContributionItems(IServiceLocator serviceLocator, IContributionRoot additions) {
+    public void createContributionItems(final IServiceLocator serviceLocator, final IContributionRoot additions) {
         for (IContributionItem item : items) {
             additions.addContributionItem(item, null);
         }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/MenuContributionFactory.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/MenuContributionFactory.java
@@ -1,0 +1,38 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+package software.aws.toolkits.eclipse.amazonq.views.actions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jface.action.ActionContributionItem;
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.action.IContributionItem;
+import org.eclipse.ui.menus.AbstractContributionFactory;
+import org.eclipse.ui.menus.IContributionRoot;
+import org.eclipse.ui.services.IServiceLocator;
+
+public class MenuContributionFactory extends AbstractContributionFactory {
+
+    private List<IContributionItem> items = new ArrayList<>();
+
+    public MenuContributionFactory(String location) {
+        super("menu:" + location, null);
+    }
+
+    public void addContributionItem(IContributionItem item) {
+        items.add(item);
+    }
+
+    public void addAction(IAction action) {
+        items.add(new ActionContributionItem(action));
+    }
+
+    @Override
+    public void createContributionItems(IServiceLocator serviceLocator, IContributionRoot additions) {
+        for (IContributionItem item : items) {
+            additions.addContributionItem(item, null);
+        }
+    }
+
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/OpenQChatAction.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/OpenQChatAction.java
@@ -1,0 +1,23 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.views.actions;
+
+import org.eclipse.jface.action.Action;
+
+import software.aws.toolkits.eclipse.amazonq.telemetry.UiTelemetryProvider;
+import software.aws.toolkits.eclipse.amazonq.views.ViewVisibilityManager;
+
+public class OpenQChatAction extends Action {
+
+    public OpenQChatAction() {
+        setText("Open Q Chat");
+    }
+
+    @Override
+    public final void run() {
+        UiTelemetryProvider.emitClickEventMetric("ellipses_openQChat");
+        ViewVisibilityManager.showChatView("ellipsesMenu");
+    }
+
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/ToggleAutoTriggerContributionItem.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/ToggleAutoTriggerContributionItem.java
@@ -10,7 +10,6 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
-import org.eclipse.ui.IViewSite;
 
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.AuthState;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
@@ -22,12 +21,10 @@ public final class ToggleAutoTriggerContributionItem extends ContributionItem {
     private static final String PAUSE_TEXT = "Pause Auto-Suggestions";
     private static final String RESUME_TEXT = "Resume Auto-Suggestions";
 
-    private IViewSite viewSite;
     private Image pause;
     private Image resume;
 
-    public ToggleAutoTriggerContributionItem(final IViewSite viewSite) {
-        this.viewSite = viewSite;
+    public ToggleAutoTriggerContributionItem() {
         var pauseImageDescriptor = Activator.imageDescriptorFromPlugin("org.eclipse.ui.navigator",
                 "icons/full/clcl16/pause.png");
         pause = pauseImageDescriptor.createImage(Display.getCurrent());
@@ -38,10 +35,6 @@ public final class ToggleAutoTriggerContributionItem extends ContributionItem {
 
     public void updateVisibility(final AuthState authState) {
         this.setVisible(authState.isLoggedIn());
-        Display.getDefault().asyncExec(() -> {
-            viewSite.getActionBars().getMenuManager().markDirty();
-            viewSite.getActionBars().getMenuManager().update(true);
-        });
     }
 
     @Override


### PR DESCRIPTION
*Description of changes:*
Makes the Q top-level toolbar icon have a dropdown when the user is logged in. This provides another avenue for accessing plugin actions and options even when a user has closed the Q Chat view.

![image](https://github.com/user-attachments/assets/6d73e0f3-0616-49d6-bd5b-e9bda1cb7945)

The same options are available as the hamburger menu on the Q Chat panel, with the addition of an explicit item to open Q Chat.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
