### PR TITLE
Fix common actions bug

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/CustomizationDialogContributionItem.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/CustomizationDialogContributionItem.java
@@ -14,6 +14,9 @@ import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.Shell;
 
 import jakarta.inject.Inject;
+import software.aws.toolkits.eclipse.amazonq.broker.api.EventObserver;
+import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.AuthState;
+import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.LoginType;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
 import software.aws.toolkits.eclipse.amazonq.telemetry.UiTelemetryProvider;
 import software.aws.toolkits.eclipse.amazonq.util.Constants;
@@ -21,15 +24,17 @@ import software.aws.toolkits.eclipse.amazonq.views.CustomizationDialog;
 import software.aws.toolkits.eclipse.amazonq.views.CustomizationDialog.ResponseSelection;
 import software.aws.toolkits.eclipse.amazonq.views.model.Customization;
 
-public final class CustomizationDialogContributionItem extends ContributionItem {
+public final class CustomizationDialogContributionItem extends ContributionItem implements EventObserver<AuthState> {
     private static final String CUSTOMIZATION_MENU_ITEM_TEXT = "Select Customization";
 
     @Inject
     private Shell shell;
 
     @Override
-    public void setVisible(final boolean isVisible) {
-        super.setVisible(isVisible);
+    public void onEvent(final AuthState authState) {
+        // TODO: Need to update this method as the login condition has to be Pro login
+        // using IAM identity center
+        this.setVisible(authState.isLoggedIn() && authState.loginType().equals(LoginType.IAM_IDENTITY_CENTER));
     }
 
     @Override

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/FeedbackDialogContributionItem.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/FeedbackDialogContributionItem.java
@@ -3,10 +3,12 @@ package software.aws.toolkits.eclipse.amazonq.views.actions;
 import org.eclipse.swt.widgets.Shell;
 
 import jakarta.inject.Inject;
+import software.aws.toolkits.eclipse.amazonq.broker.api.EventObserver;
+import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.AuthState;
 import software.aws.toolkits.eclipse.amazonq.views.DialogContributionItem;
 import software.aws.toolkits.eclipse.amazonq.views.FeedbackDialog;
 
-public final class FeedbackDialogContributionItem {
+public final class FeedbackDialogContributionItem implements EventObserver<AuthState> {
     private static final String SHARE_FEEDBACK_MENU_ITEM_TEXT = "Share Feedback...";
 
     @Inject
@@ -21,8 +23,9 @@ public final class FeedbackDialogContributionItem {
         );
     }
 
-    public void setVisible(final boolean isVisible) {
-        feedbackDialogContributionItem.setVisible(isVisible);
+    @Override
+    public void onEvent(final AuthState authState) {
+        feedbackDialogContributionItem.setVisible(authState.isLoggedIn());
     }
 
     public DialogContributionItem getDialogContributionItem() {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/SignoutAction.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/SignoutAction.java
@@ -2,6 +2,7 @@ package software.aws.toolkits.eclipse.amazonq.views.actions;
 
 import org.eclipse.jface.action.Action;
 
+import software.aws.toolkits.eclipse.amazonq.broker.api.EventObserver;
 import software.aws.toolkits.eclipse.amazonq.customization.CustomizationUtil;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.AuthState;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
@@ -10,10 +11,11 @@ import software.aws.toolkits.eclipse.amazonq.util.Constants;
 import software.aws.toolkits.eclipse.amazonq.util.PluginUtils;
 import software.aws.toolkits.eclipse.amazonq.util.ThreadingUtils;
 
-public final class SignoutAction extends Action {
+public final class SignoutAction extends Action implements EventObserver<AuthState> {
 
     public SignoutAction() {
         setText("Sign out");
+        Activator.getEventBroker().subscribe(AuthState.class, this);
     }
 
     @Override
@@ -37,8 +39,9 @@ public final class SignoutAction extends Action {
         });
     }
 
-    public void setVisible(final boolean isVisible) {
-        super.setEnabled(isVisible);
+    @Override
+    public void onEvent(final AuthState authState) {
+        this.setEnabled(authState.isLoggedIn());
     }
 
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/ToggleAutoTriggerContributionItem.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/ToggleAutoTriggerContributionItem.java
@@ -11,10 +11,12 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 
+import software.aws.toolkits.eclipse.amazonq.broker.api.EventObserver;
+import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.AuthState;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
 import software.aws.toolkits.eclipse.amazonq.telemetry.UiTelemetryProvider;
 
-public final class ToggleAutoTriggerContributionItem extends ContributionItem {
+public final class ToggleAutoTriggerContributionItem extends ContributionItem implements EventObserver<AuthState> {
 
     public static final String AUTO_TRIGGER_ENABLEMENT_KEY = "aws.q.autotrigger.eclipse";
     private static final String PAUSE_TEXT = "Pause Auto-Suggestions";
@@ -33,8 +35,8 @@ public final class ToggleAutoTriggerContributionItem extends ContributionItem {
     }
 
     @Override
-    public void setVisible(final boolean isVisible) {
-        super.setVisible(isVisible);
+    public void onEvent(final AuthState authState) {
+        this.setVisible(authState.isLoggedIn());
     }
 
     @Override


### PR DESCRIPTION
*Description of changes:*
- Signout Action would not reenable after first sign out in the global pulldown menu.
- The setEnable call was not propagating to both local and global pulldowns simultaneously. 
- Fixed this issue and other similar potential issues by subscribing to AuthState inside the actions, and letting the actions themselves determine whether they should be enabled or disabled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
