### PR TITLE
Fix View Container timing issue

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQViewContainer.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQViewContainer.java
@@ -34,8 +34,6 @@ public final class AmazonQViewContainer extends ViewPart implements EventObserve
         activeViewType = AmazonQViewType.CHAT_VIEW;
         containerLock = new ReentrantLock(true);
 
-        Activator.getEventBroker().subscribe(AmazonQViewType.class, this);
-
         views = Map.of(
                 AmazonQViewType.CHAT_ASSET_MISSING_VIEW, new ChatAssetMissingView(),
                 AmazonQViewType.DEPENDENCY_MISSING_VIEW, new DependencyMissingView(),
@@ -44,6 +42,8 @@ public final class AmazonQViewContainer extends ViewPart implements EventObserve
                 AmazonQViewType.CHAT_VIEW, new AmazonQChatWebview(),
                 AmazonQViewType.TOOLKIT_LOGIN_VIEW, new ToolkitLoginWebview()
         );
+
+        Activator.getEventBroker().subscribe(AmazonQViewType.class, this);
     }
 
     @Override
@@ -107,7 +107,7 @@ public final class AmazonQViewContainer extends ViewPart implements EventObserve
       activeViewType = newViewType;
       containerLock.unlock();
 
-      if (!parentComposite.isDisposed()) {
+      if (parentComposite != null && !parentComposite.isDisposed()) {
           updateChildView();
       }
     }


### PR DESCRIPTION
*Description of changes:*
- Fix race condition causing onEvent to be called before views map is setup.
- Fix bug where onEvent is called before the login view is rendered for the first time causing the parentComposite to be null.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
