### PR TITLE
Add notification event for insert at cursor and prompt option change

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
@@ -17,6 +17,7 @@ import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.swt.widgets.Display;
 
 import software.aws.toolkits.eclipse.amazonq.chat.models.BaseChatRequestParams;
+import software.aws.toolkits.eclipse.amazonq.chat.models.PromptInputOptionChangeParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.ChatRequestParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.ChatResult;
 import software.aws.toolkits.eclipse.amazonq.chat.models.ChatUIInboundCommand;
@@ -102,6 +103,11 @@ public final class ChatCommunicationManager {
                         return chatMessageProvider.sendChatPrompt(chatRequestParams.getTabId(),
                                 encryptedChatRequestParams);
                     });
+                    break;
+                case CHAT_PROMPT_OPTION_CHANGE:
+                    PromptInputOptionChangeParams promptInputOptionChangeParams = jsonHandler.convertObject(params,
+                            PromptInputOptionChangeParams.class);
+                    chatMessageProvider.sendPromptInputOptionChange(promptInputOptionChangeParams);
                     break;
                 case CHAT_QUICK_ACTION:
                     QuickActionParams quickActionParams = jsonHandler.convertObject(params, QuickActionParams.class);

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
@@ -30,6 +30,7 @@ import software.aws.toolkits.eclipse.amazonq.chat.models.FollowUpClickParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.GenericLinkClickParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.GenericTabParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.InlineChatRequestParams;
+import software.aws.toolkits.eclipse.amazonq.chat.models.InsertToCursorPositionParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.QuickActionParams;
 import software.aws.toolkits.eclipse.amazonq.exception.AmazonQPluginException;
 import software.aws.toolkits.eclipse.amazonq.lsp.encryption.DefaultLspEncryptionManager;
@@ -130,19 +131,13 @@ public final class ChatCommunicationManager {
                     chatMessageProvider.sendTabChange(tabParamsForChange);
                     break;
                 case CHAT_INFO_LINK_CLICK:
-                    GenericLinkClickParams infoLinkClickParams = jsonHandler.convertObject(params,
-                            GenericLinkClickParams.class);
-                    chatMessageProvider.sendInfoLinkClick(infoLinkClickParams);
+                    chatMessageProvider.sendInfoLinkClick((GenericLinkClickParams) params);
                     break;
                 case CHAT_LINK_CLICK:
-                    GenericLinkClickParams linkClickParams = jsonHandler.convertObject(params,
-                            GenericLinkClickParams.class);
-                    chatMessageProvider.sendLinkClick(linkClickParams);
+                    chatMessageProvider.sendLinkClick((GenericLinkClickParams) params);
                     break;
                 case CHAT_SOURCE_LINK_CLICK:
-                    GenericLinkClickParams sourceLinkClickParams = jsonHandler.convertObject(params,
-                            GenericLinkClickParams.class);
-                    chatMessageProvider.sendSourceLinkClick(sourceLinkClickParams);
+                    chatMessageProvider.sendSourceLinkClick((GenericLinkClickParams) params);
                     break;
                 case CHAT_FOLLOW_UP_CLICK:
                     FollowUpClickParams followUpClickParams = jsonHandler.convertObject(params,
@@ -152,6 +147,10 @@ public final class ChatCommunicationManager {
                 case CHAT_END_CHAT:
                     GenericTabParams tabParamsForEndChat = jsonHandler.convertObject(params, GenericTabParams.class);
                     chatMessageProvider.endChat(tabParamsForEndChat);
+                    break;
+                case CHAT_INSERT_TO_CURSOR_POSITION:
+                    chatMessageProvider.sendInsertToCursorPositionParams((InsertToCursorPositionParams) params);
+                    chatMessageProvider.sendTelemetryEvent(params);
                     break;
                 case CHAT_FEEDBACK:
                     var feedbackParams = jsonHandler.convertObject(params, FeedbackParams.class);

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatMessage.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatMessage.java
@@ -11,6 +11,7 @@ import software.aws.toolkits.eclipse.amazonq.chat.models.FeedbackParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.FollowUpClickParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.GenericTabParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.InsertToCursorPositionParams;
+import software.aws.toolkits.eclipse.amazonq.chat.models.PromptInputOptionChangeParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.GenericLinkClickParams;
 import software.aws.toolkits.eclipse.amazonq.lsp.AmazonQLspServer;
 
@@ -37,6 +38,10 @@ public final class ChatMessage {
 
     public CompletableFuture<Boolean> endChat(final GenericTabParams tabParams) {
         return amazonQLspServer.endChat(tabParams);
+    }
+
+    public void sendPromptInputOptionChange(final PromptInputOptionChangeParams optionChangeParams) {
+        amazonQLspServer.promptInputOptionChange(optionChangeParams);
     }
 
     public void sendChatReady() {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatMessage.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatMessage.java
@@ -10,6 +10,7 @@ import software.aws.toolkits.eclipse.amazonq.chat.models.EncryptedQuickActionPar
 import software.aws.toolkits.eclipse.amazonq.chat.models.FeedbackParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.FollowUpClickParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.GenericTabParams;
+import software.aws.toolkits.eclipse.amazonq.chat.models.InsertToCursorPositionParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.GenericLinkClickParams;
 import software.aws.toolkits.eclipse.amazonq.lsp.AmazonQLspServer;
 
@@ -64,6 +65,10 @@ public final class ChatMessage {
 
     public void sendSourceLinkClickParams(final GenericLinkClickParams sourceLinkClickParams) {
         amazonQLspServer.sourceLinkClick(sourceLinkClickParams);
+    }
+
+    public void sendInsertToCursorPositionParams(final InsertToCursorPositionParams insertToCursorParams) {
+        amazonQLspServer.insertToCursorPosition(insertToCursorParams);
     }
 
     public void followUpClick(final FollowUpClickParams followUpClickParams) {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatMessageProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatMessageProvider.java
@@ -13,6 +13,7 @@ import software.aws.toolkits.eclipse.amazonq.chat.models.FeedbackParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.FollowUpClickParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.GenericTabParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.InsertToCursorPositionParams;
+import software.aws.toolkits.eclipse.amazonq.chat.models.PromptInputOptionChangeParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.GenericLinkClickParams;
 import software.aws.toolkits.eclipse.amazonq.lsp.AmazonQLspServer;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
@@ -69,6 +70,11 @@ public final class ChatMessageProvider {
     public CompletableFuture<Boolean> endChat(final GenericTabParams tabParams) {
         ChatMessage chatMessage = new ChatMessage(amazonQLspServer);
         return chatMessage.endChat(tabParams);
+    }
+
+    public void sendPromptInputOptionChange(final PromptInputOptionChangeParams optionChangeParams) {
+        ChatMessage chatMessage = new ChatMessage(amazonQLspServer);
+        chatMessage.sendPromptInputOptionChange(optionChangeParams);
     }
 
     public void sendChatReady() {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatMessageProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatMessageProvider.java
@@ -12,6 +12,7 @@ import software.aws.toolkits.eclipse.amazonq.chat.models.EncryptedQuickActionPar
 import software.aws.toolkits.eclipse.amazonq.chat.models.FeedbackParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.FollowUpClickParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.GenericTabParams;
+import software.aws.toolkits.eclipse.amazonq.chat.models.InsertToCursorPositionParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.GenericLinkClickParams;
 import software.aws.toolkits.eclipse.amazonq.lsp.AmazonQLspServer;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
@@ -104,6 +105,11 @@ public final class ChatMessageProvider {
     public void sendSourceLinkClick(final GenericLinkClickParams sourceLinkClickParams) {
         ChatMessage chatMessage = new ChatMessage(amazonQLspServer);
         chatMessage.sendSourceLinkClickParams(sourceLinkClickParams);
+    }
+
+    public void sendInsertToCursorPositionParams(final InsertToCursorPositionParams insertToCursorPositionParams) {
+        ChatMessage chatMessage = new ChatMessage(amazonQLspServer);
+        chatMessage.sendInsertToCursorPositionParams(insertToCursorPositionParams);
     }
 
     public void followUpClick(final FollowUpClickParams followUpClickParams) {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/models/PromptInputOptionChangeParams.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/models/PromptInputOptionChangeParams.java
@@ -1,0 +1,13 @@
+package software.aws.toolkits.eclipse.amazonq.chat.models;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record PromptInputOptionChangeParams(
+        @JsonProperty("tabId") String tabId,
+        @JsonProperty("optionsValues") Map<String, String> optionValues,
+        @JsonProperty("eventId") String eventId) {
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServer.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServer.java
@@ -15,6 +15,7 @@ import software.aws.toolkits.eclipse.amazonq.chat.models.FollowUpClickParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.GenericLinkClickParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.GenericTabParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.InsertToCursorPositionParams;
+import software.aws.toolkits.eclipse.amazonq.chat.models.PromptInputOptionChangeParams;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.GetSsoTokenParams;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.GetSsoTokenResult;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.InvalidateSsoTokenParams;
@@ -68,6 +69,9 @@ public interface AmazonQLspServer extends LanguageServer {
 
     @JsonNotification("aws/chat/followUpClick")
     void followUpClick(FollowUpClickParams params);
+
+    @JsonNotification("aws/chat/promptInputOptionChange")
+    void promptInputOptionChange(PromptInputOptionChangeParams params);
 
     @JsonNotification("aws/chat/ready")
     void chatReady();

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServer.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServer.java
@@ -14,6 +14,7 @@ import software.aws.toolkits.eclipse.amazonq.chat.models.FeedbackParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.FollowUpClickParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.GenericLinkClickParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.GenericTabParams;
+import software.aws.toolkits.eclipse.amazonq.chat.models.InsertToCursorPositionParams;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.GetSsoTokenParams;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.GetSsoTokenResult;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.InvalidateSsoTokenParams;
@@ -73,6 +74,9 @@ public interface AmazonQLspServer extends LanguageServer {
 
     @JsonNotification("aws/chat/feedback")
     void sendFeedback(FeedbackParams params);
+
+    @JsonNotification("aws/chat/insertToCursorPosition")
+    void insertToCursorPosition(InsertToCursorPositionParams params);
 
     @JsonRequest("aws/credentials/token/update")
     CompletableFuture<ResponseMessage> updateTokenCredentials(UpdateCredentialsPayload payload);

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatViewActionHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatViewActionHandler.java
@@ -56,6 +56,9 @@ public class AmazonQChatViewActionHandler implements ViewActionHandler {
             case CHAT_SEND_PROMPT:
                 chatCommunicationManager.sendMessageToChatServer(command, params);
                 break;
+            case CHAT_PROMPT_OPTION_CHANGE:
+                chatCommunicationManager.sendMessageToChatServer(command, params);
+                break;
             case CHAT_QUICK_ACTION:
                 chatCommunicationManager.sendMessageToChatServer(command, params);
                 break;

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatViewActionHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatViewActionHandler.java
@@ -65,7 +65,7 @@ public class AmazonQChatViewActionHandler implements ViewActionHandler {
                 GenericLinkClickParams linkClickParams = jsonHandler.convertObject(params,
                         GenericLinkClickParams.class);
                 validateAndHandleLink(linkClickParams.getLink());
-                chatCommunicationManager.sendMessageToChatServer(command, params);
+                chatCommunicationManager.sendMessageToChatServer(command, linkClickParams);
                 break;
             case CHAT_READY:
                 chatCommunicationManager.sendMessageToChatServer(command, params);
@@ -92,7 +92,7 @@ public class AmazonQChatViewActionHandler implements ViewActionHandler {
                     insertToCursorParams.setTextDocument(new TextDocumentIdentifier(filePathUri));
                     cursorState.ifPresent(state -> insertToCursorParams.setCursorState(Arrays.asList(state)));
                 });
-                chatCommunicationManager.sendMessageToChatServer(Command.TELEMETRY_EVENT, insertToCursorParams);
+                chatCommunicationManager.sendMessageToChatServer(command, insertToCursorParams);
                 break;
             case CHAT_FEEDBACK:
                 chatCommunicationManager.sendMessageToChatServer(command, params);

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/Command.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/Command.java
@@ -14,6 +14,7 @@ public enum Command {
     CHAT_TAB_REMOVE("aws/chat/tabRemove"),
     CHAT_TAB_CHANGE("aws/chat/tabChange"),
     CHAT_SEND_PROMPT("aws/chat/sendChatPrompt"),
+    CHAT_PROMPT_OPTION_CHANGE("aws/chat/promptInputOptionChange"),
     CHAT_LINK_CLICK("aws/chat/linkClick"),
     CHAT_INFO_LINK_CLICK("aws/chat/infoLinkClick"),
     CHAT_SOURCE_LINK_CLICK("aws/chat/sourceLinkClick"),


### PR DESCRIPTION
*Description of changes:*
This PR adds notification events for insert at cursor and prompt option change, as well as optimizations for the link click notification events. Prompt option change was net new, and insert at cursor event was existing but not sending a notification. The existing logic for this command has been updated to include this emission.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
