### PR TITLE
Add replay capability to event broker

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/broker/EventBroker.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/broker/EventBroker.java
@@ -89,9 +89,12 @@ public final class EventBroker {
                 if (statefulSubjectsByIdForType.containsKey(eventType)) {
                     ReentrantLock subjectLock = getStatefulSubjectLock(eventType);
                     for (String subscriberId : statefulSubjectsByIdForType.get(eventType).keySet()) {
-                        subjectLock.lock();
-                        statefulSubjectsByIdForType.get(eventType).get(subscriberId).onNext(event);
-                        subjectLock.unlock();
+                        try {
+                            subjectLock.lock();
+                            statefulSubjectsByIdForType.get(eventType).get(subscriberId).onNext(event);
+                        } finally {
+                            subjectLock.unlock();
+                        }
                     }
                 }
             }).subscribe();

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/broker/api/MissedReplayEventObserver.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/broker/api/MissedReplayEventObserver.java
@@ -1,0 +1,10 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.broker.api;
+
+public interface MissedReplayEventObserver<T> extends EventObserver<T> {
+
+    String getSubscribingComponentId();
+
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
@@ -260,7 +260,7 @@ public final class ChatCommunicationManager {
                         : ChatUIInboundCommandName.ChatPrompt.getValue();
                     ChatUIInboundCommand chatUIInboundCommand = new ChatUIInboundCommand(
                             command, tabId, result, false);
-                    sendMessageToChatUI(chatUIInboundCommand);
+                    Activator.getEventBroker().post(ChatUIInboundCommand.class, chatUIInboundCommand);
                     return result;
                 } catch (Exception e) {
                     Activator.getLogger().error("An error occurred while processing chat response received: " + e.getMessage());
@@ -278,7 +278,7 @@ public final class ChatCommunicationManager {
         // show error in Chat UI
         ChatUIInboundCommand chatUIInboundCommand = new ChatUIInboundCommand(
                 ChatUIInboundCommandName.ErrorMessage.getValue(), tabId, errorParams, false);
-        sendMessageToChatUI(chatUIInboundCommand);
+        Activator.getEventBroker().post(ChatUIInboundCommand.class, chatUIInboundCommand);
     }
 
     public void setChatUiRequestListener(final ChatUiRequestListener listener) {
@@ -309,11 +309,6 @@ public final class ChatCommunicationManager {
         String inlineChatCommand = ChatUIInboundCommandName.InlineChatPrompt.getValue();
         if (inlineChatCommand.equals(command.command())) {
             inlineChatListenerFuture.thenApply(listener -> {
-                listener.onSendToChatUi(message);
-                return listener;
-            });
-        } else {
-            chatUiRequestListenerFuture.thenApply(listener -> {
                 listener.onSendToChatUi(message);
                 return listener;
             });
@@ -357,7 +352,7 @@ public final class ChatCommunicationManager {
         ChatUIInboundCommand chatUIInboundCommand = new ChatUIInboundCommand(
                 command, tabId, partialChatResult, true);
 
-        sendMessageToChatUI(chatUIInboundCommand);
+        Activator.getEventBroker().post(ChatUIInboundCommand.class, chatUIInboundCommand);
     }
 
     /*

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/inlineChat/InlineChatSession.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/inlineChat/InlineChatSession.java
@@ -173,7 +173,7 @@ public final class InlineChatSession extends FoldingListener
         String message = JSON_HANDLER.serialize(chatUIInboundCommand);
         String inlineChatCommand = ChatUIInboundCommandName.InlineChatPrompt.getValue();
 
-        if (!isSessionActive() || !inlineChatCommand.equals(chatUIInboundCommand.command()) || message == null) {
+        if (!isSessionActive() || !inlineChatCommand.equals(chatUIInboundCommand.command())) {
             return;
         }
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/inlineChat/InlineChatSession.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/inlineChat/InlineChatSession.java
@@ -61,7 +61,7 @@ public final class InlineChatSession extends FoldingListener
     private boolean referencesEnabled;
     private IWorkbenchPage workbenchPage;
     private ProjectionAnnotationModel projectionModel;
-    private final JsonHandler jsonHandler;
+    private static final JsonHandler JSON_HANDLER = new JsonHandler();
 
     // Dependencies
     private final InlineChatUIManager uiManager;
@@ -83,13 +83,12 @@ public final class InlineChatSession extends FoldingListener
     private final int aboutToUndo = 17; // 17 maps to this event type
 
     private InlineChatSession() {
-        Activator.getEventBroker().subscribe(ChatUIInboundCommand.class, this);
         uiManager = InlineChatUIManager.getInstance();
         diffManager = InlineChatDiffManager.getInstance();
         themeDetector = new ThemeDetector();
         chatCommunicationManager = ChatCommunicationManager.getInstance();
         contextService = PlatformUI.getWorkbench().getService(IContextService.class);
-        jsonHandler = new JsonHandler();
+        Activator.getEventBroker().subscribe(ChatUIInboundCommand.class, this);
     }
 
     public static synchronized InlineChatSession getInstance() {
@@ -171,10 +170,10 @@ public final class InlineChatSession extends FoldingListener
     // Chat server response handler
     @Override
     public void onEvent(final ChatUIInboundCommand chatUIInboundCommand) {
-        String message = jsonHandler.serialize(chatUIInboundCommand);
+        String message = JSON_HANDLER.serialize(chatUIInboundCommand);
         String inlineChatCommand = ChatUIInboundCommandName.InlineChatPrompt.getValue();
 
-        if (!isSessionActive() || !inlineChatCommand.equals(chatUIInboundCommand.command())) {
+        if (!isSessionActive() || !inlineChatCommand.equals(chatUIInboundCommand.command()) || message == null) {
             return;
         }
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/plugin/Activator.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/plugin/Activator.java
@@ -60,6 +60,7 @@ public class Activator extends AbstractUIPlugin {
     @Override
     public final void stop(final BundleContext context) throws Exception {
         ChatStateManager.getInstance().dispose();
+        eventBroker.dispose();
         super.stop(context);
         plugin = null;
         workspaceListener.stop();

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/assets/ChatWebViewAssetProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/assets/ChatWebViewAssetProvider.java
@@ -16,12 +16,9 @@ import org.eclipse.swt.browser.ProgressAdapter;
 import org.eclipse.swt.browser.ProgressEvent;
 import org.eclipse.swt.widgets.Display;
 
-import io.reactivex.rxjava3.disposables.Disposable;
-import software.aws.toolkits.eclipse.amazonq.broker.api.EventObserver;
 import software.aws.toolkits.eclipse.amazonq.broker.events.ChatWebViewAssetState;
 import software.aws.toolkits.eclipse.amazonq.chat.ChatCommunicationManager;
 import software.aws.toolkits.eclipse.amazonq.chat.ChatTheme;
-import software.aws.toolkits.eclipse.amazonq.chat.models.ChatUIInboundCommand;
 import software.aws.toolkits.eclipse.amazonq.configuration.PluginStoreKeys;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
 import software.aws.toolkits.eclipse.amazonq.providers.lsp.LspManagerProvider;
@@ -34,7 +31,7 @@ import software.aws.toolkits.eclipse.amazonq.views.LoginViewCommandParser;
 import software.aws.toolkits.eclipse.amazonq.views.ViewActionHandler;
 import software.aws.toolkits.eclipse.amazonq.views.ViewCommandParser;
 
-public final class ChatWebViewAssetProvider extends WebViewAssetProvider implements EventObserver<ChatUIInboundCommand> {
+public final class ChatWebViewAssetProvider extends WebViewAssetProvider {
 
     private WebviewAssetServer webviewAssetServer;
     private final ChatTheme chatTheme;
@@ -42,8 +39,6 @@ public final class ChatWebViewAssetProvider extends WebViewAssetProvider impleme
     private final ViewActionHandler actionHandler;
     private final ChatCommunicationManager chatCommunicationManager;
     private Optional<String> content;
-    private Disposable chatUICommandSubscription;
-
     public ChatWebViewAssetProvider() {
         chatTheme = new ChatTheme();
         commandParser = new LoginViewCommandParser();
@@ -98,7 +93,6 @@ public final class ChatWebViewAssetProvider extends WebViewAssetProvider impleme
                 Display.getDefault().syncExec(() -> {
                     try {
                         chatTheme.injectTheme(browser);
-                        chatUICommandSubscription = Activator.getEventBroker().subscribeWithReplay(ChatUIInboundCommand.class, ChatWebViewAssetProvider.this);
                     } catch (Exception e) {
                         Activator.getLogger().info("Error occurred while injecting theme into Q chat", e);
                     }
@@ -413,11 +407,6 @@ public final class ChatWebViewAssetProvider extends WebViewAssetProvider impleme
         }
     }
 
-    @Override
-    public void onEvent(final ChatUIInboundCommand command) {
-        chatCommunicationManager.sendMessageToChatUI(command);
-    }
-
     public Optional<String> resolveJsPath() {
         var chatUiDirectory = getChatUiDirectory();
 
@@ -466,10 +455,6 @@ public final class ChatWebViewAssetProvider extends WebViewAssetProvider impleme
             webviewAssetServer.stop();
         }
         webviewAssetServer = null;
-        if (chatUICommandSubscription != null) {
-            chatUICommandSubscription.dispose();
-            chatUICommandSubscription = null;
-        }
     }
 
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQViewContainer.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQViewContainer.java
@@ -25,16 +25,13 @@ public final class AmazonQViewContainer extends ViewPart implements EventObserve
 
     private Composite parentComposite;
     private volatile StackLayout layout;
-    private Map<AmazonQViewType, BaseAmazonQView> views;
+    private static final Map<AmazonQViewType, BaseAmazonQView> VIEWS;
     private volatile AmazonQViewType activeViewType;
     private volatile BaseAmazonQView currentView;
     private final ReentrantLock containerLock;
 
-    public AmazonQViewContainer() {
-        activeViewType = AmazonQViewType.CHAT_VIEW;
-        containerLock = new ReentrantLock(true);
-
-        views = Map.of(
+    static {
+        VIEWS = Map.of(
                 AmazonQViewType.CHAT_ASSET_MISSING_VIEW, new ChatAssetMissingView(),
                 AmazonQViewType.DEPENDENCY_MISSING_VIEW, new DependencyMissingView(),
                 AmazonQViewType.RE_AUTHENTICATE_VIEW, new ReauthenticateView(),
@@ -42,6 +39,11 @@ public final class AmazonQViewContainer extends ViewPart implements EventObserve
                 AmazonQViewType.CHAT_VIEW, new AmazonQChatWebview(),
                 AmazonQViewType.TOOLKIT_LOGIN_VIEW, new ToolkitLoginWebview()
         );
+    }
+
+    public AmazonQViewContainer() {
+        activeViewType = AmazonQViewType.CHAT_VIEW;
+        containerLock = new ReentrantLock(true);
 
         Activator.getEventBroker().subscribe(AmazonQViewType.class, this);
     }
@@ -65,7 +67,7 @@ public final class AmazonQViewContainer extends ViewPart implements EventObserve
         Display.getDefault().asyncExec(() -> {
             try {
                 containerLock.lock();
-                BaseAmazonQView newView = views.get(activeViewType);
+                BaseAmazonQView newView = VIEWS.get(activeViewType);
 
                 if (currentView != null) {
                     if (currentView instanceof AmazonQChatWebview) {
@@ -99,7 +101,7 @@ public final class AmazonQViewContainer extends ViewPart implements EventObserve
 
     @Override
     public void onEvent(final AmazonQViewType newViewType) {
-        if (newViewType.equals(activeViewType) || !views.containsKey(newViewType)) {
+        if (newViewType.equals(activeViewType) || !VIEWS.containsKey(newViewType)) {
           return;
       }
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/SignoutAction.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/actions/SignoutAction.java
@@ -16,7 +16,7 @@ import software.aws.toolkits.eclipse.amazonq.util.ThreadingUtils;
 public final class SignoutAction extends Action {
 
     public SignoutAction() {
-        setText("Sign out");
+        super("Sign out");
     }
 
     @Override

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManagerTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManagerTest.java
@@ -1,556 +1,538 @@
-// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-package software.aws.toolkits.eclipse.amazonq.chat;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
-
-import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.ProgressParams;
-import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
-import org.eclipse.lsp4j.WorkDoneProgressNotification;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
-import org.eclipse.swt.widgets.Display;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.MockitoAnnotations;
-
-import software.aws.toolkits.eclipse.amazonq.chat.models.ChatItemAction;
-import software.aws.toolkits.eclipse.amazonq.chat.models.ChatPrompt;
-import software.aws.toolkits.eclipse.amazonq.chat.models.ChatRequestParams;
-import software.aws.toolkits.eclipse.amazonq.chat.models.ChatResult;
-import software.aws.toolkits.eclipse.amazonq.chat.models.ChatUIInboundCommand;
-import software.aws.toolkits.eclipse.amazonq.chat.models.CursorState;
-import software.aws.toolkits.eclipse.amazonq.chat.models.EncryptedChatParams;
-import software.aws.toolkits.eclipse.amazonq.chat.models.EncryptedQuickActionParams;
-import software.aws.toolkits.eclipse.amazonq.chat.models.FeedbackParams;
-import software.aws.toolkits.eclipse.amazonq.chat.models.FeedbackPayload;
-import software.aws.toolkits.eclipse.amazonq.chat.models.FollowUp;
-import software.aws.toolkits.eclipse.amazonq.chat.models.FollowUpClickParams;
-import software.aws.toolkits.eclipse.amazonq.chat.models.GenericTabParams;
-import software.aws.toolkits.eclipse.amazonq.chat.models.QuickActionParams;
-import software.aws.toolkits.eclipse.amazonq.chat.models.RecommendationContentSpan;
-import software.aws.toolkits.eclipse.amazonq.chat.models.ReferenceTrackerInformation;
-import software.aws.toolkits.eclipse.amazonq.chat.models.RelatedContent;
-import software.aws.toolkits.eclipse.amazonq.chat.models.SourceLink;
-import software.aws.toolkits.eclipse.amazonq.exception.AmazonQPluginException;
-import software.aws.toolkits.eclipse.amazonq.extensions.implementation.ActivatorStaticMockExtension;
-import software.aws.toolkits.eclipse.amazonq.lsp.encryption.LspEncryptionManager;
-import software.aws.toolkits.eclipse.amazonq.util.CodeReferenceLoggingService;
-import software.aws.toolkits.eclipse.amazonq.util.JsonHandler;
-import software.aws.toolkits.eclipse.amazonq.util.LoggingService;
-import software.aws.toolkits.eclipse.amazonq.util.ProgressNotificationUtils;
-import software.aws.toolkits.eclipse.amazonq.views.ChatUiRequestListener;
-import software.aws.toolkits.eclipse.amazonq.views.model.ChatCodeReference;
-import software.aws.toolkits.eclipse.amazonq.views.model.Command;
-
-public final class ChatCommunicationManagerTest {
-
-    @Mock
-    private JsonHandler jsonHandler;
-
-    @Mock
-    private LspEncryptionManager lspEncryptionManager;
-
-    @Mock
-    private ChatMessageProvider chatMessageProvider;
-
-    @Mock
-    private CompletableFuture<ChatMessageProvider> chatMessageProviderFuture;
-
-    @Mock
-    private ChatUiRequestListener chatUiRequestListener;
-
-    @Mock
-    private ChatPartialResultMap chatPartialResultMap;
-
-    @Mock
-    private Display display;
-
-    private ChatCommunicationManager chatCommunicationManager;
-
-
-    @BeforeEach
-    void setupBeforeEach() {
-        MockitoAnnotations.openMocks(this);
-        // Make sure thenAcceptAsync runs on the main thread
-        doAnswer(invocation -> {
-            Consumer<? super ChatMessageProvider> consumer = invocation.getArgument(0);
-            consumer.accept(chatMessageProvider);
-            return CompletableFuture.completedFuture(null);
-        }).when(chatMessageProviderFuture).thenAcceptAsync(ArgumentMatchers.<Consumer<? super ChatMessageProvider>>any(), any());
-
-        chatCommunicationManager = spy(ChatCommunicationManager.builder()
-                .withJsonHandler(jsonHandler)
-                .withLspEncryptionManager(lspEncryptionManager)
-                .withChatMessageProvider(chatMessageProviderFuture)
-                .withChatPartialResultMap(chatPartialResultMap)
-                .build());
-
-        when(lspEncryptionManager.encrypt(any(String.class))).thenReturn("encrypted-message");
-        when(lspEncryptionManager.decrypt(any(String.class))).thenReturn("decrypted response");
-
-    }
-
-    @Nested
-    class SendChatPromptTests {
-
-        @RegisterExtension
-        private static ActivatorStaticMockExtension activatorStaticMockExtension = new ActivatorStaticMockExtension();
-
-        private final CursorState cursorState = new CursorState(new Range(new Position(0, 0), new Position(1, 1)));
-
-        private final ChatRequestParams params = new ChatRequestParams(
-            "tabId",
-            new ChatPrompt("prompt", "escaped prompt", "command", Collections.emptyList()),
-            new TextDocumentIdentifier("textDocument"),
-            Arrays.asList(cursorState),
-            Collections.emptyList()
-        );
-
-        private final ChatItemAction chatItemAction = new ChatItemAction(
-            "pillText", "prompt", false, "description", "button"
-        );
-
-        private final ReferenceTrackerInformation referenceTracker = new ReferenceTrackerInformation(
-            "licenseName",
-            "repository",
-            "url",
-            new RecommendationContentSpan(1, 2),
-            "information"
-        );
-
-        private final ChatResult chatResult = new ChatResult(
-            "body",
-            "messageId",
-            true,
-            new RelatedContent("title", new SourceLink[]{new SourceLink("title", "url", "body")}),
-            new FollowUp("text", new ChatItemAction[]{chatItemAction}),
-            new ReferenceTrackerInformation[]{referenceTracker}
-        );
-
-        private CodeReferenceLoggingService codeReferenceLoggingService;
-
-        @BeforeEach
-        void setupBeforeEach() {
-            chatCommunicationManager.setChatUiRequestListener(chatUiRequestListener);
-            codeReferenceLoggingService = activatorStaticMockExtension.getMock(CodeReferenceLoggingService.class);
-            doReturn(Optional.of("fileUri")).when(chatCommunicationManager).getOpenFileUri();
-            doReturn(Optional.of(cursorState)).when(chatCommunicationManager).getSelectionRangeCursorState();
-        }
-
-        @Test
-        void testChatSendPrompt() {
-            when(jsonHandler.convertObject(any(Object.class), eq(ChatRequestParams.class)))
-                    .thenReturn(params);
-            when(chatMessageProvider.sendChatPrompt(any(String.class), any(EncryptedChatParams.class)))
-                    .thenReturn(CompletableFuture.completedFuture("chat response"));
-
-            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
-                    .thenReturn(chatResult);
-            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
-
-            try (MockedStatic<Display> displayMock = mockStatic(Display.class)) {
-                displayMock.when(Display::getDefault).thenReturn(display);
-                chatCommunicationManager.sendMessageToChatServer(Command.CHAT_SEND_PROMPT, params);
-            }
-
-            verify(jsonHandler).convertObject(any(Object.class), eq(ChatRequestParams.class));
-            verify(chatPartialResultMap).setEntry(any(String.class), eq("tabId"));
-            verify(chatPartialResultMap).removeEntry(any(String.class));
-
-            verify(lspEncryptionManager).encrypt(params);
-            verify(chatMessageProvider).sendChatPrompt(eq("tabId"), any(EncryptedChatParams.class));
-            verify(chatUiRequestListener).onSendToChatUi("serializedObject");
-            verify(codeReferenceLoggingService).log(any(ChatCodeReference.class));
-        }
-
-        @Test
-        void testChatSendPromptWithErrorCommunicatingWithServer() {
-            when(jsonHandler.convertObject(any(Object.class), eq(ChatRequestParams.class)))
-                    .thenReturn(params);
-            when(chatMessageProvider.sendChatPrompt(any(String.class), any(EncryptedChatParams.class)))
-                    .thenReturn(CompletableFuture.failedFuture(new RuntimeException("error message")));
-            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
-                    .thenReturn(chatResult);
-            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
-
-            try (MockedStatic<Display> displayMock = mockStatic(Display.class)) {
-                displayMock.when(Display::getDefault).thenReturn(display);
-                chatCommunicationManager.sendMessageToChatServer(Command.CHAT_SEND_PROMPT, params);
-            }
-
-            verify(chatUiRequestListener).onSendToChatUi("serializedObject");
-            verify(activatorStaticMockExtension.getMock(LoggingService.class)).error(argThat(message ->
-                message.contains("An error occurred while processing chat request")));
-        }
-
-        @Test
-        void testChatSendPromptWithErrorInResponse() {
-            when(jsonHandler.convertObject(any(Object.class), eq(ChatRequestParams.class)))
-                    .thenReturn(params);
-            when(chatMessageProvider.sendChatPrompt(any(String.class), any(EncryptedChatParams.class)))
-                    .thenReturn(CompletableFuture.completedFuture("chat response"));
-            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
-                    .thenThrow(new RuntimeException("Test exception"));
-            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
-
-            try (MockedStatic<Display> displayMock = mockStatic(Display.class)) {
-                displayMock.when(Display::getDefault).thenReturn(display);
-                chatCommunicationManager.sendMessageToChatServer(Command.CHAT_SEND_PROMPT, params);
-            }
-
-            verify(chatUiRequestListener).onSendToChatUi("serializedObject");
-            verify(activatorStaticMockExtension.getMock(LoggingService.class)).error(argThat(message ->
-                message.contains("An error occurred while processing chat response")));
-        }
-
-    }
-
-    @Nested
-    class SendQuickActionsTests {
-
-        @RegisterExtension
-        private static ActivatorStaticMockExtension activatorStaticMockExtension = new ActivatorStaticMockExtension();
-
-        private final QuickActionParams quickActionParams = new QuickActionParams("tabId", "quickAction", "prompt");
-
-        private final ChatItemAction chatItemAction = new ChatItemAction(
-            "pillText", "prompt", false, "description", "button"
-        );
-
-        private final ReferenceTrackerInformation referenceTracker = new ReferenceTrackerInformation(
-            "licenseName",
-            "repository",
-            "url",
-            new RecommendationContentSpan(1, 2),
-            "information"
-        );
-
-        private final ChatResult chatResult = new ChatResult(
-                "body",
-                "messageId",
-                true,
-                new RelatedContent("title", new SourceLink[]{new SourceLink("title", "url", "body")}),
-                new FollowUp("text", new ChatItemAction[]{chatItemAction}),
-                new ReferenceTrackerInformation[]{referenceTracker}
-            );
-
-        @BeforeEach
-        void setupBeforeEach() {
-            chatCommunicationManager.setChatUiRequestListener(chatUiRequestListener);
-        }
-
-        @Test
-        void testSendQuickAction() {
-            when(jsonHandler.convertObject(any(Object.class), eq(QuickActionParams.class)))
-                    .thenReturn(quickActionParams);
-            when(chatMessageProvider.sendQuickAction(any(String.class), any(EncryptedQuickActionParams.class)))
-                    .thenReturn(CompletableFuture.completedFuture("chat response"));
-
-            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
-                    .thenReturn(chatResult);
-            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
-
-            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_QUICK_ACTION, quickActionParams);
-
-            verify(jsonHandler).convertObject(any(Object.class), eq(QuickActionParams.class));
-            verify(chatPartialResultMap).setEntry(any(String.class), eq("tabId"));
-            verify(chatPartialResultMap).removeEntry(any(String.class));
-
-            verify(lspEncryptionManager).encrypt(quickActionParams);
-            verify(chatMessageProvider).sendQuickAction(eq("tabId"), any(EncryptedQuickActionParams.class));
-            verify(chatUiRequestListener).onSendToChatUi("serializedObject");
-        }
-
-        @Test
-        void testChatSendPromptWithErrorCommunicatingWithServer() {
-            when(jsonHandler.convertObject(any(Object.class), eq(QuickActionParams.class)))
-                    .thenReturn(quickActionParams);
-            when(chatMessageProvider.sendQuickAction(any(String.class), any(EncryptedQuickActionParams.class)))
-                    .thenReturn(CompletableFuture.failedFuture(new RuntimeException("error message")));
-
-            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
-                    .thenReturn(chatResult);
-            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
-
-            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_QUICK_ACTION, quickActionParams);
-
-            verify(chatUiRequestListener).onSendToChatUi("serializedObject");
-            verify(activatorStaticMockExtension.getMock(LoggingService.class)).error(argThat(message ->
-                message.contains("An error occurred while processing chat request")));
-        }
-
-        @Test
-        void testChatSendPromptWithErrorInResponse() {
-            when(jsonHandler.convertObject(any(Object.class), eq(QuickActionParams.class)))
-                    .thenReturn(quickActionParams);
-            when(chatMessageProvider.sendQuickAction(any(String.class), any(EncryptedQuickActionParams.class)))
-                    .thenReturn(CompletableFuture.completedFuture("chat response"));
-
-            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
-                    .thenThrow(new RuntimeException("Test exception"));
-            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
-
-            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_QUICK_ACTION, quickActionParams);
-
-            verify(chatUiRequestListener).onSendToChatUi("serializedObject");
-            verify(activatorStaticMockExtension.getMock(LoggingService.class)).error(argThat(message ->
-                message.contains("An error occurred while processing chat response")));
-        }
-
-    }
-
-    @Nested
-    class SendChatReadyAndTelemetryEventTests {
-
-        @Test
-        void testSendQuickAction() {
-            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_READY, new Object());
-            verify(chatMessageProvider).sendChatReady();
-        }
-
-        @Test
-        void testTelemetryEvent() {
-            chatCommunicationManager.sendMessageToChatServer(Command.TELEMETRY_EVENT, new Object());
-            verify(chatMessageProvider).sendTelemetryEvent(any(Object.class));
-        }
-
-    }
-
-    @Nested
-    class SendTabUpdateTests {
-
-        private final GenericTabParams genericTabParams = new GenericTabParams("tabId");
-
-        @BeforeEach
-        void setupBeforeEach() {
-            when(jsonHandler.convertObject(any(Object.class), eq(GenericTabParams.class)))
-                    .thenReturn(genericTabParams);
-        }
-
-        @Test
-        void testChatTabAdd() {
-            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_TAB_ADD, genericTabParams);
-            verify(chatMessageProvider).sendTabAdd(genericTabParams);
-        }
-
-        @Test
-        void testChatTabRemove() {
-            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_TAB_REMOVE, genericTabParams);
-            verify(chatMessageProvider).sendTabRemove(genericTabParams);
-        }
-
-        @Test
-        void testChatTabChange() {
-            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_TAB_CHANGE, genericTabParams);
-            verify(chatMessageProvider).sendTabChange(genericTabParams);
-        }
-
-        @Test
-        void testEndChat() {
-            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_END_CHAT, genericTabParams);
-            verify(chatMessageProvider).endChat(genericTabParams);
-        }
-
-    }
-
-    @Nested
-    class SendFollowUpClickTests {
-
-        private final ChatItemAction chatItemAction = new ChatItemAction(
-            "pillText", "prompt", false, "description", "button"
-        );
-
-        private final FollowUpClickParams followUpClickParams = new FollowUpClickParams("tabId", "messageId", chatItemAction);
-
-        @BeforeEach
-        void setupBeforeEach() {
-            when(jsonHandler.convertObject(any(Object.class), eq(FollowUpClickParams.class)))
-                    .thenReturn(followUpClickParams);
-        }
-
-        @Test
-        void testFollowUpClick() {
-            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_FOLLOW_UP_CLICK, followUpClickParams);
-            verify(chatMessageProvider).followUpClick(followUpClickParams);
-        }
-
-    }
-
-    @Nested
-    class SendFeedbackTests {
-
-        private final FeedbackPayload feedbackPayload = new FeedbackPayload("messageId", "tabId", "selectedOption", "commend");
-        private final FeedbackParams feedbackParams = new FeedbackParams("tabId", "eventId", feedbackPayload);
-
-        @BeforeEach
-        void setupBeforeEach() {
-            when(jsonHandler.convertObject(any(Object.class), eq(FeedbackParams.class)))
-                    .thenReturn(feedbackParams);
-        }
-
-        @Test
-        void testFollowUpClick() {
-            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_FEEDBACK, feedbackParams);
-            verify(chatMessageProvider).sendFeedback(feedbackParams);
-        }
-
-    }
-
-    @Nested
-    class HandlePartialResultProgressNotificationTests {
-
-        @Mock
-        private ProgressParams progressParams;
-
-        @BeforeEach
-        void setupBeforeEach() {
-            MockitoAnnotations.openMocks(this);
-            chatCommunicationManager.setChatUiRequestListener(chatUiRequestListener);
-        }
-
-        @Test
-        void testWithNullTabId() {
-            try (MockedStatic<ProgressNotificationUtils> progressNotificationUtilsMock = mockStatic(ProgressNotificationUtils.class)) {
-                progressNotificationUtilsMock
-                        .when(() -> ProgressNotificationUtils.getToken(any(ProgressParams.class)))
-                        .thenReturn("token");
-                when(chatPartialResultMap.getValue(any(String.class))).thenReturn(null);
-
-                chatCommunicationManager.handlePartialResultProgressNotification(progressParams);
-
-                verifyNoInteractions(lspEncryptionManager);
-                verifyNoInteractions(jsonHandler);
-                verifyNoInteractions(chatUiRequestListener);
-            }
-        }
-
-        @Test
-        void testWithEmptyTabId() {
-            try (MockedStatic<ProgressNotificationUtils> progressNotificationUtilsMock = mockStatic(ProgressNotificationUtils.class)) {
-                progressNotificationUtilsMock
-                        .when(() -> ProgressNotificationUtils.getToken(any(ProgressParams.class)))
-                        .thenReturn("token");
-                when(chatPartialResultMap.getValue(any(String.class))).thenReturn("");
-
-                chatCommunicationManager.handlePartialResultProgressNotification(progressParams);
-
-                verifyNoInteractions(lspEncryptionManager);
-                verifyNoInteractions(jsonHandler);
-                verifyNoInteractions(chatUiRequestListener);
-            }
-        }
-
-        @Test
-        void testIncorrectParamsObject() {
-            try (MockedStatic<ProgressNotificationUtils> progressNotificationUtilsMock = mockStatic(ProgressNotificationUtils.class)) {
-                progressNotificationUtilsMock
-                        .when(() -> ProgressNotificationUtils.getToken(any(ProgressParams.class)))
-                        .thenReturn("token");
-                when(chatPartialResultMap.getValue(any(String.class))).thenReturn("tabId");
-
-                Either<WorkDoneProgressNotification, Object> either = mock(Either.class);
-                when(either.isLeft()).thenReturn(true);
-                when(progressParams.getValue()).thenReturn(either);
-
-                assertThrows(AmazonQPluginException.class, () -> chatCommunicationManager.handlePartialResultProgressNotification(progressParams));
-
-                verifyNoInteractions(lspEncryptionManager);
-                verifyNoInteractions(jsonHandler);
-                verifyNoInteractions(chatUiRequestListener);
-            }
-        }
-
-        @Test
-        void testIncorrectChatPartialResult() {
-            try (MockedStatic<ProgressNotificationUtils> progressNotificationUtilsMock = mockStatic(ProgressNotificationUtils.class)) {
-                progressNotificationUtilsMock
-                        .when(() -> ProgressNotificationUtils.getToken(any(ProgressParams.class)))
-                        .thenReturn("token");
-                when(chatPartialResultMap.getValue(any(String.class))).thenReturn("tabId");
-
-                Either<WorkDoneProgressNotification, Object> either = mock(Either.class);
-                when(either.getRight()).thenReturn(new Object());
-                when(progressParams.getValue()).thenReturn(either);
-
-                progressNotificationUtilsMock
-                    .when(() -> ProgressNotificationUtils.getObject(any(ProgressParams.class), eq(String.class)))
-                    .thenReturn("chatPartialResult");
-
-                ChatResult chatResult = mock(ChatResult.class);
-
-                when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class))).thenReturn(chatResult);
-                when(chatResult.body()).thenReturn(null);
-
-                chatCommunicationManager.handlePartialResultProgressNotification(progressParams);
-
-                verifyNoInteractions(chatUiRequestListener);
-            }
-        }
-
-        @Test
-        void testChatPartialResult() {
-            try (MockedStatic<ProgressNotificationUtils> progressNotificationUtilsMock = mockStatic(ProgressNotificationUtils.class)) {
-                progressNotificationUtilsMock
-                        .when(() -> ProgressNotificationUtils.getToken(any(ProgressParams.class)))
-                        .thenReturn("token");
-                when(chatPartialResultMap.getValue(any(String.class))).thenReturn("tabId");
-
-                Either<WorkDoneProgressNotification, Object> either = mock(Either.class);
-                when(either.getRight()).thenReturn(new Object());
-                when(progressParams.getValue()).thenReturn(either);
-
-                progressNotificationUtilsMock
-                    .when(() -> ProgressNotificationUtils.getObject(any(ProgressParams.class), eq(String.class)))
-                    .thenReturn("chatPartialResult");
-
-                ChatResult chatResult = mock(ChatResult.class);
-
-                when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class))).thenReturn(chatResult);
-                when(chatResult.body()).thenReturn("body");
-                when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
-
-                chatCommunicationManager.handlePartialResultProgressNotification(progressParams);
-
-                verify(chatUiRequestListener).onSendToChatUi("serializedObject");
-            }
-        }
-
-    }
-
-    @Test
-    void sendMessageToChatServerFails() {
-        when(jsonHandler.convertObject(any(Object.class), eq(ChatRequestParams.class)))
-                .thenThrow(new RuntimeException("Test exception"));
-
-        try (MockedStatic<Display> displayMock = mockStatic(Display.class)) {
-            displayMock.when(Display::getDefault).thenReturn(display);
-            assertThrows(AmazonQPluginException.class, () -> chatCommunicationManager.sendMessageToChatServer(Command.CHAT_SEND_PROMPT, new Object()));
-        }
-    }
-
-}
+//// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//// SPDX-License-Identifier: Apache-2.0
+//
+//package software.aws.toolkits.eclipse.amazonq.chat;
+//
+//import static org.junit.jupiter.api.Assertions.assertThrows;
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.ArgumentMatchers.argThat;
+//import static org.mockito.ArgumentMatchers.eq;
+//import static org.mockito.Mockito.doAnswer;
+//import static org.mockito.Mockito.doReturn;
+//import static org.mockito.Mockito.mock;
+//import static org.mockito.Mockito.mockStatic;
+//import static org.mockito.Mockito.spy;
+//import static org.mockito.Mockito.verify;
+//import static org.mockito.Mockito.verifyNoInteractions;
+//import static org.mockito.Mockito.when;
+//
+//import java.util.Arrays;
+//import java.util.Collections;
+//import java.util.Optional;
+//import java.util.concurrent.CompletableFuture;
+//import java.util.function.Consumer;
+//
+//import org.eclipse.lsp4j.Position;
+//import org.eclipse.lsp4j.ProgressParams;
+//import org.eclipse.lsp4j.Range;
+//import org.eclipse.lsp4j.TextDocumentIdentifier;
+//import org.eclipse.lsp4j.WorkDoneProgressNotification;
+//import org.eclipse.lsp4j.jsonrpc.messages.Either;
+//import org.eclipse.swt.widgets.Display;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Nested;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.RegisterExtension;
+//import org.mockito.ArgumentMatchers;
+//import org.mockito.Mock;
+//import org.mockito.MockedStatic;
+//import org.mockito.MockitoAnnotations;
+//
+//import software.aws.toolkits.eclipse.amazonq.chat.models.ChatItemAction;
+//import software.aws.toolkits.eclipse.amazonq.chat.models.ChatPrompt;
+//import software.aws.toolkits.eclipse.amazonq.chat.models.ChatRequestParams;
+//import software.aws.toolkits.eclipse.amazonq.chat.models.ChatResult;
+//import software.aws.toolkits.eclipse.amazonq.chat.models.ChatUIInboundCommand;
+//import software.aws.toolkits.eclipse.amazonq.chat.models.CursorState;
+//import software.aws.toolkits.eclipse.amazonq.chat.models.EncryptedChatParams;
+//import software.aws.toolkits.eclipse.amazonq.chat.models.EncryptedQuickActionParams;
+//import software.aws.toolkits.eclipse.amazonq.chat.models.FeedbackParams;
+//import software.aws.toolkits.eclipse.amazonq.chat.models.FeedbackPayload;
+//import software.aws.toolkits.eclipse.amazonq.chat.models.FollowUp;
+//import software.aws.toolkits.eclipse.amazonq.chat.models.FollowUpClickParams;
+//import software.aws.toolkits.eclipse.amazonq.chat.models.GenericTabParams;
+//import software.aws.toolkits.eclipse.amazonq.chat.models.QuickActionParams;
+//import software.aws.toolkits.eclipse.amazonq.chat.models.RecommendationContentSpan;
+//import software.aws.toolkits.eclipse.amazonq.chat.models.ReferenceTrackerInformation;
+//import software.aws.toolkits.eclipse.amazonq.chat.models.RelatedContent;
+//import software.aws.toolkits.eclipse.amazonq.chat.models.SourceLink;
+//import software.aws.toolkits.eclipse.amazonq.exception.AmazonQPluginException;
+//import software.aws.toolkits.eclipse.amazonq.extensions.implementation.ActivatorStaticMockExtension;
+//import software.aws.toolkits.eclipse.amazonq.lsp.encryption.LspEncryptionManager;
+//import software.aws.toolkits.eclipse.amazonq.util.CodeReferenceLoggingService;
+//import software.aws.toolkits.eclipse.amazonq.util.JsonHandler;
+//import software.aws.toolkits.eclipse.amazonq.util.LoggingService;
+//import software.aws.toolkits.eclipse.amazonq.util.ProgressNotificationUtils;
+//import software.aws.toolkits.eclipse.amazonq.views.model.ChatCodeReference;
+//import software.aws.toolkits.eclipse.amazonq.views.model.Command;
+//
+//public final class ChatCommunicationManagerTest {
+//
+//    @Mock
+//    private JsonHandler jsonHandler;
+//
+//    @Mock
+//    private LspEncryptionManager lspEncryptionManager;
+//
+//    @Mock
+//    private ChatMessageProvider chatMessageProvider;
+//
+//    @Mock
+//    private CompletableFuture<ChatMessageProvider> chatMessageProviderFuture;
+//
+//    @Mock
+//    private ChatPartialResultMap chatPartialResultMap;
+//
+//    @Mock
+//    private Display display;
+//
+//    private ChatCommunicationManager chatCommunicationManager;
+//
+//
+//    @BeforeEach
+//    void setupBeforeEach() {
+//        MockitoAnnotations.openMocks(this);
+//        // Make sure thenAcceptAsync runs on the main thread
+//        doAnswer(invocation -> {
+//            Consumer<? super ChatMessageProvider> consumer = invocation.getArgument(0);
+//            consumer.accept(chatMessageProvider);
+//            return CompletableFuture.completedFuture(null);
+//        }).when(chatMessageProviderFuture).thenAcceptAsync(ArgumentMatchers.<Consumer<? super ChatMessageProvider>>any(), any());
+//
+//        chatCommunicationManager = spy(ChatCommunicationManager.builder()
+//                .withJsonHandler(jsonHandler)
+//                .withLspEncryptionManager(lspEncryptionManager)
+//                .withChatMessageProvider(chatMessageProviderFuture)
+//                .withChatPartialResultMap(chatPartialResultMap)
+//                .build());
+//
+//        when(lspEncryptionManager.encrypt(any(String.class))).thenReturn("encrypted-message");
+//        when(lspEncryptionManager.decrypt(any(String.class))).thenReturn("decrypted response");
+//
+//    }
+//
+//    @Nested
+//    class SendChatPromptTests {
+//
+//        @RegisterExtension
+//        private static ActivatorStaticMockExtension activatorStaticMockExtension = new ActivatorStaticMockExtension();
+//
+//        private final CursorState cursorState = new CursorState(new Range(new Position(0, 0), new Position(1, 1)));
+//
+//        private final ChatRequestParams params = new ChatRequestParams(
+//            "tabId",
+//            new ChatPrompt("prompt", "escaped prompt", "command", Collections.emptyList()),
+//            new TextDocumentIdentifier("textDocument"),
+//            Arrays.asList(cursorState),
+//            Collections.emptyList()
+//        );
+//
+//        private final ChatItemAction chatItemAction = new ChatItemAction(
+//            "pillText", "prompt", false, "description", "button"
+//        );
+//
+//        private final ReferenceTrackerInformation referenceTracker = new ReferenceTrackerInformation(
+//            "licenseName",
+//            "repository",
+//            "url",
+//            new RecommendationContentSpan(1, 2),
+//            "information"
+//        );
+//
+//        private final ChatResult chatResult = new ChatResult(
+//            "body",
+//            "messageId",
+//            true,
+//            new RelatedContent("title", new SourceLink[]{new SourceLink("title", "url", "body")}),
+//            new FollowUp("text", new ChatItemAction[]{chatItemAction}),
+//            new ReferenceTrackerInformation[]{referenceTracker}
+//        );
+//
+//        private CodeReferenceLoggingService codeReferenceLoggingService;
+//
+//        @BeforeEach
+//        void setupBeforeEach() {
+//            codeReferenceLoggingService = activatorStaticMockExtension.getMock(CodeReferenceLoggingService.class);
+//            doReturn(Optional.of("fileUri")).when(chatCommunicationManager).getOpenFileUri();
+//            doReturn(Optional.of(cursorState)).when(chatCommunicationManager).getSelectionRangeCursorState();
+//        }
+//
+//        @Test
+//        void testChatSendPrompt() {
+//            when(jsonHandler.convertObject(any(Object.class), eq(ChatRequestParams.class)))
+//                    .thenReturn(params);
+//            when(chatMessageProvider.sendChatPrompt(any(String.class), any(EncryptedChatParams.class)))
+//                    .thenReturn(CompletableFuture.completedFuture("chat response"));
+//
+//            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
+//                    .thenReturn(chatResult);
+//            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
+//
+//            try (MockedStatic<Display> displayMock = mockStatic(Display.class)) {
+//                displayMock.when(Display::getDefault).thenReturn(display);
+//                chatCommunicationManager.sendMessageToChatServer(Command.CHAT_SEND_PROMPT, params);
+//            }
+//
+//            verify(jsonHandler).convertObject(any(Object.class), eq(ChatRequestParams.class));
+//            verify(chatPartialResultMap).setEntry(any(String.class), eq("tabId"));
+//            verify(chatPartialResultMap).removeEntry(any(String.class));
+//
+//            verify(lspEncryptionManager).encrypt(params);
+//            verify(chatMessageProvider).sendChatPrompt(eq("tabId"), any(EncryptedChatParams.class));
+//            verify(codeReferenceLoggingService).log(any(ChatCodeReference.class));
+//        }
+//
+//        @Test
+//        void testChatSendPromptWithErrorCommunicatingWithServer() {
+//            when(jsonHandler.convertObject(any(Object.class), eq(ChatRequestParams.class)))
+//                    .thenReturn(params);
+//            when(chatMessageProvider.sendChatPrompt(any(String.class), any(EncryptedChatParams.class)))
+//                    .thenReturn(CompletableFuture.failedFuture(new RuntimeException("error message")));
+//            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
+//                    .thenReturn(chatResult);
+//            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
+//
+//            try (MockedStatic<Display> displayMock = mockStatic(Display.class)) {
+//                displayMock.when(Display::getDefault).thenReturn(display);
+//                chatCommunicationManager.sendMessageToChatServer(Command.CHAT_SEND_PROMPT, params);
+//            }
+//
+//            verify(activatorStaticMockExtension.getMock(LoggingService.class)).error(argThat(message ->
+//                message.contains("An error occurred while processing chat request")));
+//        }
+//
+//        @Test
+//        void testChatSendPromptWithErrorInResponse() {
+//            when(jsonHandler.convertObject(any(Object.class), eq(ChatRequestParams.class)))
+//                    .thenReturn(params);
+//            when(chatMessageProvider.sendChatPrompt(any(String.class), any(EncryptedChatParams.class)))
+//                    .thenReturn(CompletableFuture.completedFuture("chat response"));
+//            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
+//                    .thenThrow(new RuntimeException("Test exception"));
+//            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
+//
+//            try (MockedStatic<Display> displayMock = mockStatic(Display.class)) {
+//                displayMock.when(Display::getDefault).thenReturn(display);
+//                chatCommunicationManager.sendMessageToChatServer(Command.CHAT_SEND_PROMPT, params);
+//            }
+//
+//            verify(activatorStaticMockExtension.getMock(LoggingService.class)).error(argThat(message ->
+//                message.contains("An error occurred while processing chat response")));
+//        }
+//
+//    }
+//
+//    @Nested
+//    class SendQuickActionsTests {
+//
+//        @RegisterExtension
+//        private static ActivatorStaticMockExtension activatorStaticMockExtension = new ActivatorStaticMockExtension();
+//
+//        private final QuickActionParams quickActionParams = new QuickActionParams("tabId", "quickAction", "prompt");
+//
+//        private final ChatItemAction chatItemAction = new ChatItemAction(
+//            "pillText", "prompt", false, "description", "button"
+//        );
+//
+//        private final ReferenceTrackerInformation referenceTracker = new ReferenceTrackerInformation(
+//            "licenseName",
+//            "repository",
+//            "url",
+//            new RecommendationContentSpan(1, 2),
+//            "information"
+//        );
+//
+//        private final ChatResult chatResult = new ChatResult(
+//                "body",
+//                "messageId",
+//                true,
+//                new RelatedContent("title", new SourceLink[]{new SourceLink("title", "url", "body")}),
+//                new FollowUp("text", new ChatItemAction[]{chatItemAction}),
+//                new ReferenceTrackerInformation[]{referenceTracker}
+//            );
+//
+//
+//        @Test
+//        void testSendQuickAction() {
+//            when(jsonHandler.convertObject(any(Object.class), eq(QuickActionParams.class)))
+//                    .thenReturn(quickActionParams);
+//            when(chatMessageProvider.sendQuickAction(any(String.class), any(EncryptedQuickActionParams.class)))
+//                    .thenReturn(CompletableFuture.completedFuture("chat response"));
+//
+//            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
+//                    .thenReturn(chatResult);
+//            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
+//
+//            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_QUICK_ACTION, quickActionParams);
+//
+//            verify(jsonHandler).convertObject(any(Object.class), eq(QuickActionParams.class));
+//            verify(chatPartialResultMap).setEntry(any(String.class), eq("tabId"));
+//            verify(chatPartialResultMap).removeEntry(any(String.class));
+//
+//            verify(lspEncryptionManager).encrypt(quickActionParams);
+//            verify(chatMessageProvider).sendQuickAction(eq("tabId"), any(EncryptedQuickActionParams.class));
+//        }
+//
+//        @Test
+//        void testChatSendPromptWithErrorCommunicatingWithServer() {
+//            when(jsonHandler.convertObject(any(Object.class), eq(QuickActionParams.class)))
+//                    .thenReturn(quickActionParams);
+//            when(chatMessageProvider.sendQuickAction(any(String.class), any(EncryptedQuickActionParams.class)))
+//                    .thenReturn(CompletableFuture.failedFuture(new RuntimeException("error message")));
+//
+//            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
+//                    .thenReturn(chatResult);
+//            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
+//
+//            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_QUICK_ACTION, quickActionParams);
+//
+//            verify(activatorStaticMockExtension.getMock(LoggingService.class)).error(argThat(message ->
+//                message.contains("An error occurred while processing chat request")));
+//        }
+//
+//        @Test
+//        void testChatSendPromptWithErrorInResponse() {
+//            when(jsonHandler.convertObject(any(Object.class), eq(QuickActionParams.class)))
+//                    .thenReturn(quickActionParams);
+//            when(chatMessageProvider.sendQuickAction(any(String.class), any(EncryptedQuickActionParams.class)))
+//                    .thenReturn(CompletableFuture.completedFuture("chat response"));
+//
+//            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
+//                    .thenThrow(new RuntimeException("Test exception"));
+//            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
+//
+//            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_QUICK_ACTION, quickActionParams);
+//
+//            verify(activatorStaticMockExtension.getMock(LoggingService.class)).error(argThat(message ->
+//                message.contains("An error occurred while processing chat response")));
+//        }
+//
+//    }
+//
+//    @Nested
+//    class SendChatReadyAndTelemetryEventTests {
+//
+//        @Test
+//        void testSendQuickAction() {
+//            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_READY, new Object());
+//            verify(chatMessageProvider).sendChatReady();
+//        }
+//
+//        @Test
+//        void testTelemetryEvent() {
+//            chatCommunicationManager.sendMessageToChatServer(Command.TELEMETRY_EVENT, new Object());
+//            verify(chatMessageProvider).sendTelemetryEvent(any(Object.class));
+//        }
+//
+//    }
+//
+//    @Nested
+//    class SendTabUpdateTests {
+//
+//        private final GenericTabParams genericTabParams = new GenericTabParams("tabId");
+//
+//        @BeforeEach
+//        void setupBeforeEach() {
+//            when(jsonHandler.convertObject(any(Object.class), eq(GenericTabParams.class)))
+//                    .thenReturn(genericTabParams);
+//        }
+//
+//        @Test
+//        void testChatTabAdd() {
+//            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_TAB_ADD, genericTabParams);
+//            verify(chatMessageProvider).sendTabAdd(genericTabParams);
+//        }
+//
+//        @Test
+//        void testChatTabRemove() {
+//            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_TAB_REMOVE, genericTabParams);
+//            verify(chatMessageProvider).sendTabRemove(genericTabParams);
+//        }
+//
+//        @Test
+//        void testChatTabChange() {
+//            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_TAB_CHANGE, genericTabParams);
+//            verify(chatMessageProvider).sendTabChange(genericTabParams);
+//        }
+//
+//        @Test
+//        void testEndChat() {
+//            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_END_CHAT, genericTabParams);
+//            verify(chatMessageProvider).endChat(genericTabParams);
+//        }
+//
+//    }
+//
+//    @Nested
+//    class SendFollowUpClickTests {
+//
+//        private final ChatItemAction chatItemAction = new ChatItemAction(
+//            "pillText", "prompt", false, "description", "button"
+//        );
+//
+//        private final FollowUpClickParams followUpClickParams = new FollowUpClickParams("tabId", "messageId", chatItemAction);
+//
+//        @BeforeEach
+//        void setupBeforeEach() {
+//            when(jsonHandler.convertObject(any(Object.class), eq(FollowUpClickParams.class)))
+//                    .thenReturn(followUpClickParams);
+//        }
+//
+//        @Test
+//        void testFollowUpClick() {
+//            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_FOLLOW_UP_CLICK, followUpClickParams);
+//            verify(chatMessageProvider).followUpClick(followUpClickParams);
+//        }
+//
+//    }
+//
+//    @Nested
+//    class SendFeedbackTests {
+//
+//        private final FeedbackPayload feedbackPayload = new FeedbackPayload("messageId", "tabId", "selectedOption", "commend");
+//        private final FeedbackParams feedbackParams = new FeedbackParams("tabId", "eventId", feedbackPayload);
+//
+//        @BeforeEach
+//        void setupBeforeEach() {
+//            when(jsonHandler.convertObject(any(Object.class), eq(FeedbackParams.class)))
+//                    .thenReturn(feedbackParams);
+//        }
+//
+//        @Test
+//        void testFollowUpClick() {
+//            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_FEEDBACK, feedbackParams);
+//            verify(chatMessageProvider).sendFeedback(feedbackParams);
+//        }
+//
+//    }
+//
+//    @Nested
+//    class HandlePartialResultProgressNotificationTests {
+//
+//        @Mock
+//        private ProgressParams progressParams;
+//
+//        @BeforeEach
+//        void setupBeforeEach() {
+//            MockitoAnnotations.openMocks(this);
+//        }
+//
+//        @Test
+//        void testWithNullTabId() {
+//            try (MockedStatic<ProgressNotificationUtils> progressNotificationUtilsMock = mockStatic(ProgressNotificationUtils.class)) {
+//                progressNotificationUtilsMock
+//                        .when(() -> ProgressNotificationUtils.getToken(any(ProgressParams.class)))
+//                        .thenReturn("token");
+//                when(chatPartialResultMap.getValue(any(String.class))).thenReturn(null);
+//
+//                chatCommunicationManager.handlePartialResultProgressNotification(progressParams);
+//
+//                verifyNoInteractions(lspEncryptionManager);
+//                verifyNoInteractions(jsonHandler);
+//            }
+//        }
+//
+//        @Test
+//        void testWithEmptyTabId() {
+//            try (MockedStatic<ProgressNotificationUtils> progressNotificationUtilsMock = mockStatic(ProgressNotificationUtils.class)) {
+//                progressNotificationUtilsMock
+//                        .when(() -> ProgressNotificationUtils.getToken(any(ProgressParams.class)))
+//                        .thenReturn("token");
+//                when(chatPartialResultMap.getValue(any(String.class))).thenReturn("");
+//
+//                chatCommunicationManager.handlePartialResultProgressNotification(progressParams);
+//
+//                verifyNoInteractions(lspEncryptionManager);
+//                verifyNoInteractions(jsonHandler);
+//            }
+//        }
+//
+//        @Test
+//        void testIncorrectParamsObject() {
+//            try (MockedStatic<ProgressNotificationUtils> progressNotificationUtilsMock = mockStatic(ProgressNotificationUtils.class)) {
+//                progressNotificationUtilsMock
+//                        .when(() -> ProgressNotificationUtils.getToken(any(ProgressParams.class)))
+//                        .thenReturn("token");
+//                when(chatPartialResultMap.getValue(any(String.class))).thenReturn("tabId");
+//
+//                Either<WorkDoneProgressNotification, Object> either = mock(Either.class);
+//                when(either.isLeft()).thenReturn(true);
+//                when(progressParams.getValue()).thenReturn(either);
+//
+//                assertThrows(AmazonQPluginException.class, () -> chatCommunicationManager.handlePartialResultProgressNotification(progressParams));
+//
+//                verifyNoInteractions(lspEncryptionManager);
+//                verifyNoInteractions(jsonHandler);
+//                verifyNoInteractions(chatUiRequestListener);
+//            }
+//        }
+//
+//        @Test
+//        void testIncorrectChatPartialResult() {
+//            try (MockedStatic<ProgressNotificationUtils> progressNotificationUtilsMock = mockStatic(ProgressNotificationUtils.class)) {
+//                progressNotificationUtilsMock
+//                        .when(() -> ProgressNotificationUtils.getToken(any(ProgressParams.class)))
+//                        .thenReturn("token");
+//                when(chatPartialResultMap.getValue(any(String.class))).thenReturn("tabId");
+//
+//                Either<WorkDoneProgressNotification, Object> either = mock(Either.class);
+//                when(either.getRight()).thenReturn(new Object());
+//                when(progressParams.getValue()).thenReturn(either);
+//
+//                progressNotificationUtilsMock
+//                    .when(() -> ProgressNotificationUtils.getObject(any(ProgressParams.class), eq(String.class)))
+//                    .thenReturn("chatPartialResult");
+//
+//                ChatResult chatResult = mock(ChatResult.class);
+//
+//                when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class))).thenReturn(chatResult);
+//                when(chatResult.body()).thenReturn(null);
+//
+//                chatCommunicationManager.handlePartialResultProgressNotification(progressParams);
+//
+//                verifyNoInteractions(chatUiRequestListener);
+//            }
+//        }
+//
+//        @Test
+//        void testChatPartialResult() {
+//            try (MockedStatic<ProgressNotificationUtils> progressNotificationUtilsMock = mockStatic(ProgressNotificationUtils.class)) {
+//                progressNotificationUtilsMock
+//                        .when(() -> ProgressNotificationUtils.getToken(any(ProgressParams.class)))
+//                        .thenReturn("token");
+//                when(chatPartialResultMap.getValue(any(String.class))).thenReturn("tabId");
+//
+//                Either<WorkDoneProgressNotification, Object> either = mock(Either.class);
+//                when(either.getRight()).thenReturn(new Object());
+//                when(progressParams.getValue()).thenReturn(either);
+//
+//                progressNotificationUtilsMock
+//                    .when(() -> ProgressNotificationUtils.getObject(any(ProgressParams.class), eq(String.class)))
+//                    .thenReturn("chatPartialResult");
+//
+//                ChatResult chatResult = mock(ChatResult.class);
+//
+//                when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class))).thenReturn(chatResult);
+//                when(chatResult.body()).thenReturn("body");
+//                when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
+//
+//                chatCommunicationManager.handlePartialResultProgressNotification(progressParams);
+//
+//                verify(chatUiRequestListener).onSendToChatUi("serializedObject");
+//            }
+//        }
+//
+//    }
+//
+//    @Test
+//    void sendMessageToChatServerFails() {
+//        when(jsonHandler.convertObject(any(Object.class), eq(ChatRequestParams.class)))
+//                .thenThrow(new RuntimeException("Test exception"));
+//
+//        try (MockedStatic<Display> displayMock = mockStatic(Display.class)) {
+//            displayMock.when(Display::getDefault).thenReturn(display);
+//            assertThrows(AmazonQPluginException.class, () -> chatCommunicationManager.sendMessageToChatServer(Command.CHAT_SEND_PROMPT, new Object()));
+//        }
+//    }
+//
+//}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManagerTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManagerTest.java
@@ -1,538 +1,554 @@
-//// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-//// SPDX-License-Identifier: Apache-2.0
-//
-//package software.aws.toolkits.eclipse.amazonq.chat;
-//
-//import static org.junit.jupiter.api.Assertions.assertThrows;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.argThat;
-//import static org.mockito.ArgumentMatchers.eq;
-//import static org.mockito.Mockito.doAnswer;
-//import static org.mockito.Mockito.doReturn;
-//import static org.mockito.Mockito.mock;
-//import static org.mockito.Mockito.mockStatic;
-//import static org.mockito.Mockito.spy;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.verifyNoInteractions;
-//import static org.mockito.Mockito.when;
-//
-//import java.util.Arrays;
-//import java.util.Collections;
-//import java.util.Optional;
-//import java.util.concurrent.CompletableFuture;
-//import java.util.function.Consumer;
-//
-//import org.eclipse.lsp4j.Position;
-//import org.eclipse.lsp4j.ProgressParams;
-//import org.eclipse.lsp4j.Range;
-//import org.eclipse.lsp4j.TextDocumentIdentifier;
-//import org.eclipse.lsp4j.WorkDoneProgressNotification;
-//import org.eclipse.lsp4j.jsonrpc.messages.Either;
-//import org.eclipse.swt.widgets.Display;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Nested;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.RegisterExtension;
-//import org.mockito.ArgumentMatchers;
-//import org.mockito.Mock;
-//import org.mockito.MockedStatic;
-//import org.mockito.MockitoAnnotations;
-//
-//import software.aws.toolkits.eclipse.amazonq.chat.models.ChatItemAction;
-//import software.aws.toolkits.eclipse.amazonq.chat.models.ChatPrompt;
-//import software.aws.toolkits.eclipse.amazonq.chat.models.ChatRequestParams;
-//import software.aws.toolkits.eclipse.amazonq.chat.models.ChatResult;
-//import software.aws.toolkits.eclipse.amazonq.chat.models.ChatUIInboundCommand;
-//import software.aws.toolkits.eclipse.amazonq.chat.models.CursorState;
-//import software.aws.toolkits.eclipse.amazonq.chat.models.EncryptedChatParams;
-//import software.aws.toolkits.eclipse.amazonq.chat.models.EncryptedQuickActionParams;
-//import software.aws.toolkits.eclipse.amazonq.chat.models.FeedbackParams;
-//import software.aws.toolkits.eclipse.amazonq.chat.models.FeedbackPayload;
-//import software.aws.toolkits.eclipse.amazonq.chat.models.FollowUp;
-//import software.aws.toolkits.eclipse.amazonq.chat.models.FollowUpClickParams;
-//import software.aws.toolkits.eclipse.amazonq.chat.models.GenericTabParams;
-//import software.aws.toolkits.eclipse.amazonq.chat.models.QuickActionParams;
-//import software.aws.toolkits.eclipse.amazonq.chat.models.RecommendationContentSpan;
-//import software.aws.toolkits.eclipse.amazonq.chat.models.ReferenceTrackerInformation;
-//import software.aws.toolkits.eclipse.amazonq.chat.models.RelatedContent;
-//import software.aws.toolkits.eclipse.amazonq.chat.models.SourceLink;
-//import software.aws.toolkits.eclipse.amazonq.exception.AmazonQPluginException;
-//import software.aws.toolkits.eclipse.amazonq.extensions.implementation.ActivatorStaticMockExtension;
-//import software.aws.toolkits.eclipse.amazonq.lsp.encryption.LspEncryptionManager;
-//import software.aws.toolkits.eclipse.amazonq.util.CodeReferenceLoggingService;
-//import software.aws.toolkits.eclipse.amazonq.util.JsonHandler;
-//import software.aws.toolkits.eclipse.amazonq.util.LoggingService;
-//import software.aws.toolkits.eclipse.amazonq.util.ProgressNotificationUtils;
-//import software.aws.toolkits.eclipse.amazonq.views.model.ChatCodeReference;
-//import software.aws.toolkits.eclipse.amazonq.views.model.Command;
-//
-//public final class ChatCommunicationManagerTest {
-//
-//    @Mock
-//    private JsonHandler jsonHandler;
-//
-//    @Mock
-//    private LspEncryptionManager lspEncryptionManager;
-//
-//    @Mock
-//    private ChatMessageProvider chatMessageProvider;
-//
-//    @Mock
-//    private CompletableFuture<ChatMessageProvider> chatMessageProviderFuture;
-//
-//    @Mock
-//    private ChatPartialResultMap chatPartialResultMap;
-//
-//    @Mock
-//    private Display display;
-//
-//    private ChatCommunicationManager chatCommunicationManager;
-//
-//
-//    @BeforeEach
-//    void setupBeforeEach() {
-//        MockitoAnnotations.openMocks(this);
-//        // Make sure thenAcceptAsync runs on the main thread
-//        doAnswer(invocation -> {
-//            Consumer<? super ChatMessageProvider> consumer = invocation.getArgument(0);
-//            consumer.accept(chatMessageProvider);
-//            return CompletableFuture.completedFuture(null);
-//        }).when(chatMessageProviderFuture).thenAcceptAsync(ArgumentMatchers.<Consumer<? super ChatMessageProvider>>any(), any());
-//
-//        chatCommunicationManager = spy(ChatCommunicationManager.builder()
-//                .withJsonHandler(jsonHandler)
-//                .withLspEncryptionManager(lspEncryptionManager)
-//                .withChatMessageProvider(chatMessageProviderFuture)
-//                .withChatPartialResultMap(chatPartialResultMap)
-//                .build());
-//
-//        when(lspEncryptionManager.encrypt(any(String.class))).thenReturn("encrypted-message");
-//        when(lspEncryptionManager.decrypt(any(String.class))).thenReturn("decrypted response");
-//
-//    }
-//
-//    @Nested
-//    class SendChatPromptTests {
-//
-//        @RegisterExtension
-//        private static ActivatorStaticMockExtension activatorStaticMockExtension = new ActivatorStaticMockExtension();
-//
-//        private final CursorState cursorState = new CursorState(new Range(new Position(0, 0), new Position(1, 1)));
-//
-//        private final ChatRequestParams params = new ChatRequestParams(
-//            "tabId",
-//            new ChatPrompt("prompt", "escaped prompt", "command", Collections.emptyList()),
-//            new TextDocumentIdentifier("textDocument"),
-//            Arrays.asList(cursorState),
-//            Collections.emptyList()
-//        );
-//
-//        private final ChatItemAction chatItemAction = new ChatItemAction(
-//            "pillText", "prompt", false, "description", "button"
-//        );
-//
-//        private final ReferenceTrackerInformation referenceTracker = new ReferenceTrackerInformation(
-//            "licenseName",
-//            "repository",
-//            "url",
-//            new RecommendationContentSpan(1, 2),
-//            "information"
-//        );
-//
-//        private final ChatResult chatResult = new ChatResult(
-//            "body",
-//            "messageId",
-//            true,
-//            new RelatedContent("title", new SourceLink[]{new SourceLink("title", "url", "body")}),
-//            new FollowUp("text", new ChatItemAction[]{chatItemAction}),
-//            new ReferenceTrackerInformation[]{referenceTracker}
-//        );
-//
-//        private CodeReferenceLoggingService codeReferenceLoggingService;
-//
-//        @BeforeEach
-//        void setupBeforeEach() {
-//            codeReferenceLoggingService = activatorStaticMockExtension.getMock(CodeReferenceLoggingService.class);
-//            doReturn(Optional.of("fileUri")).when(chatCommunicationManager).getOpenFileUri();
-//            doReturn(Optional.of(cursorState)).when(chatCommunicationManager).getSelectionRangeCursorState();
-//        }
-//
-//        @Test
-//        void testChatSendPrompt() {
-//            when(jsonHandler.convertObject(any(Object.class), eq(ChatRequestParams.class)))
-//                    .thenReturn(params);
-//            when(chatMessageProvider.sendChatPrompt(any(String.class), any(EncryptedChatParams.class)))
-//                    .thenReturn(CompletableFuture.completedFuture("chat response"));
-//
-//            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
-//                    .thenReturn(chatResult);
-//            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
-//
-//            try (MockedStatic<Display> displayMock = mockStatic(Display.class)) {
-//                displayMock.when(Display::getDefault).thenReturn(display);
-//                chatCommunicationManager.sendMessageToChatServer(Command.CHAT_SEND_PROMPT, params);
-//            }
-//
-//            verify(jsonHandler).convertObject(any(Object.class), eq(ChatRequestParams.class));
-//            verify(chatPartialResultMap).setEntry(any(String.class), eq("tabId"));
-//            verify(chatPartialResultMap).removeEntry(any(String.class));
-//
-//            verify(lspEncryptionManager).encrypt(params);
-//            verify(chatMessageProvider).sendChatPrompt(eq("tabId"), any(EncryptedChatParams.class));
-//            verify(codeReferenceLoggingService).log(any(ChatCodeReference.class));
-//        }
-//
-//        @Test
-//        void testChatSendPromptWithErrorCommunicatingWithServer() {
-//            when(jsonHandler.convertObject(any(Object.class), eq(ChatRequestParams.class)))
-//                    .thenReturn(params);
-//            when(chatMessageProvider.sendChatPrompt(any(String.class), any(EncryptedChatParams.class)))
-//                    .thenReturn(CompletableFuture.failedFuture(new RuntimeException("error message")));
-//            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
-//                    .thenReturn(chatResult);
-//            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
-//
-//            try (MockedStatic<Display> displayMock = mockStatic(Display.class)) {
-//                displayMock.when(Display::getDefault).thenReturn(display);
-//                chatCommunicationManager.sendMessageToChatServer(Command.CHAT_SEND_PROMPT, params);
-//            }
-//
-//            verify(activatorStaticMockExtension.getMock(LoggingService.class)).error(argThat(message ->
-//                message.contains("An error occurred while processing chat request")));
-//        }
-//
-//        @Test
-//        void testChatSendPromptWithErrorInResponse() {
-//            when(jsonHandler.convertObject(any(Object.class), eq(ChatRequestParams.class)))
-//                    .thenReturn(params);
-//            when(chatMessageProvider.sendChatPrompt(any(String.class), any(EncryptedChatParams.class)))
-//                    .thenReturn(CompletableFuture.completedFuture("chat response"));
-//            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
-//                    .thenThrow(new RuntimeException("Test exception"));
-//            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
-//
-//            try (MockedStatic<Display> displayMock = mockStatic(Display.class)) {
-//                displayMock.when(Display::getDefault).thenReturn(display);
-//                chatCommunicationManager.sendMessageToChatServer(Command.CHAT_SEND_PROMPT, params);
-//            }
-//
-//            verify(activatorStaticMockExtension.getMock(LoggingService.class)).error(argThat(message ->
-//                message.contains("An error occurred while processing chat response")));
-//        }
-//
-//    }
-//
-//    @Nested
-//    class SendQuickActionsTests {
-//
-//        @RegisterExtension
-//        private static ActivatorStaticMockExtension activatorStaticMockExtension = new ActivatorStaticMockExtension();
-//
-//        private final QuickActionParams quickActionParams = new QuickActionParams("tabId", "quickAction", "prompt");
-//
-//        private final ChatItemAction chatItemAction = new ChatItemAction(
-//            "pillText", "prompt", false, "description", "button"
-//        );
-//
-//        private final ReferenceTrackerInformation referenceTracker = new ReferenceTrackerInformation(
-//            "licenseName",
-//            "repository",
-//            "url",
-//            new RecommendationContentSpan(1, 2),
-//            "information"
-//        );
-//
-//        private final ChatResult chatResult = new ChatResult(
-//                "body",
-//                "messageId",
-//                true,
-//                new RelatedContent("title", new SourceLink[]{new SourceLink("title", "url", "body")}),
-//                new FollowUp("text", new ChatItemAction[]{chatItemAction}),
-//                new ReferenceTrackerInformation[]{referenceTracker}
-//            );
-//
-//
-//        @Test
-//        void testSendQuickAction() {
-//            when(jsonHandler.convertObject(any(Object.class), eq(QuickActionParams.class)))
-//                    .thenReturn(quickActionParams);
-//            when(chatMessageProvider.sendQuickAction(any(String.class), any(EncryptedQuickActionParams.class)))
-//                    .thenReturn(CompletableFuture.completedFuture("chat response"));
-//
-//            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
-//                    .thenReturn(chatResult);
-//            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
-//
-//            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_QUICK_ACTION, quickActionParams);
-//
-//            verify(jsonHandler).convertObject(any(Object.class), eq(QuickActionParams.class));
-//            verify(chatPartialResultMap).setEntry(any(String.class), eq("tabId"));
-//            verify(chatPartialResultMap).removeEntry(any(String.class));
-//
-//            verify(lspEncryptionManager).encrypt(quickActionParams);
-//            verify(chatMessageProvider).sendQuickAction(eq("tabId"), any(EncryptedQuickActionParams.class));
-//        }
-//
-//        @Test
-//        void testChatSendPromptWithErrorCommunicatingWithServer() {
-//            when(jsonHandler.convertObject(any(Object.class), eq(QuickActionParams.class)))
-//                    .thenReturn(quickActionParams);
-//            when(chatMessageProvider.sendQuickAction(any(String.class), any(EncryptedQuickActionParams.class)))
-//                    .thenReturn(CompletableFuture.failedFuture(new RuntimeException("error message")));
-//
-//            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
-//                    .thenReturn(chatResult);
-//            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
-//
-//            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_QUICK_ACTION, quickActionParams);
-//
-//            verify(activatorStaticMockExtension.getMock(LoggingService.class)).error(argThat(message ->
-//                message.contains("An error occurred while processing chat request")));
-//        }
-//
-//        @Test
-//        void testChatSendPromptWithErrorInResponse() {
-//            when(jsonHandler.convertObject(any(Object.class), eq(QuickActionParams.class)))
-//                    .thenReturn(quickActionParams);
-//            when(chatMessageProvider.sendQuickAction(any(String.class), any(EncryptedQuickActionParams.class)))
-//                    .thenReturn(CompletableFuture.completedFuture("chat response"));
-//
-//            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
-//                    .thenThrow(new RuntimeException("Test exception"));
-//            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
-//
-//            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_QUICK_ACTION, quickActionParams);
-//
-//            verify(activatorStaticMockExtension.getMock(LoggingService.class)).error(argThat(message ->
-//                message.contains("An error occurred while processing chat response")));
-//        }
-//
-//    }
-//
-//    @Nested
-//    class SendChatReadyAndTelemetryEventTests {
-//
-//        @Test
-//        void testSendQuickAction() {
-//            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_READY, new Object());
-//            verify(chatMessageProvider).sendChatReady();
-//        }
-//
-//        @Test
-//        void testTelemetryEvent() {
-//            chatCommunicationManager.sendMessageToChatServer(Command.TELEMETRY_EVENT, new Object());
-//            verify(chatMessageProvider).sendTelemetryEvent(any(Object.class));
-//        }
-//
-//    }
-//
-//    @Nested
-//    class SendTabUpdateTests {
-//
-//        private final GenericTabParams genericTabParams = new GenericTabParams("tabId");
-//
-//        @BeforeEach
-//        void setupBeforeEach() {
-//            when(jsonHandler.convertObject(any(Object.class), eq(GenericTabParams.class)))
-//                    .thenReturn(genericTabParams);
-//        }
-//
-//        @Test
-//        void testChatTabAdd() {
-//            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_TAB_ADD, genericTabParams);
-//            verify(chatMessageProvider).sendTabAdd(genericTabParams);
-//        }
-//
-//        @Test
-//        void testChatTabRemove() {
-//            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_TAB_REMOVE, genericTabParams);
-//            verify(chatMessageProvider).sendTabRemove(genericTabParams);
-//        }
-//
-//        @Test
-//        void testChatTabChange() {
-//            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_TAB_CHANGE, genericTabParams);
-//            verify(chatMessageProvider).sendTabChange(genericTabParams);
-//        }
-//
-//        @Test
-//        void testEndChat() {
-//            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_END_CHAT, genericTabParams);
-//            verify(chatMessageProvider).endChat(genericTabParams);
-//        }
-//
-//    }
-//
-//    @Nested
-//    class SendFollowUpClickTests {
-//
-//        private final ChatItemAction chatItemAction = new ChatItemAction(
-//            "pillText", "prompt", false, "description", "button"
-//        );
-//
-//        private final FollowUpClickParams followUpClickParams = new FollowUpClickParams("tabId", "messageId", chatItemAction);
-//
-//        @BeforeEach
-//        void setupBeforeEach() {
-//            when(jsonHandler.convertObject(any(Object.class), eq(FollowUpClickParams.class)))
-//                    .thenReturn(followUpClickParams);
-//        }
-//
-//        @Test
-//        void testFollowUpClick() {
-//            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_FOLLOW_UP_CLICK, followUpClickParams);
-//            verify(chatMessageProvider).followUpClick(followUpClickParams);
-//        }
-//
-//    }
-//
-//    @Nested
-//    class SendFeedbackTests {
-//
-//        private final FeedbackPayload feedbackPayload = new FeedbackPayload("messageId", "tabId", "selectedOption", "commend");
-//        private final FeedbackParams feedbackParams = new FeedbackParams("tabId", "eventId", feedbackPayload);
-//
-//        @BeforeEach
-//        void setupBeforeEach() {
-//            when(jsonHandler.convertObject(any(Object.class), eq(FeedbackParams.class)))
-//                    .thenReturn(feedbackParams);
-//        }
-//
-//        @Test
-//        void testFollowUpClick() {
-//            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_FEEDBACK, feedbackParams);
-//            verify(chatMessageProvider).sendFeedback(feedbackParams);
-//        }
-//
-//    }
-//
-//    @Nested
-//    class HandlePartialResultProgressNotificationTests {
-//
-//        @Mock
-//        private ProgressParams progressParams;
-//
-//        @BeforeEach
-//        void setupBeforeEach() {
-//            MockitoAnnotations.openMocks(this);
-//        }
-//
-//        @Test
-//        void testWithNullTabId() {
-//            try (MockedStatic<ProgressNotificationUtils> progressNotificationUtilsMock = mockStatic(ProgressNotificationUtils.class)) {
-//                progressNotificationUtilsMock
-//                        .when(() -> ProgressNotificationUtils.getToken(any(ProgressParams.class)))
-//                        .thenReturn("token");
-//                when(chatPartialResultMap.getValue(any(String.class))).thenReturn(null);
-//
-//                chatCommunicationManager.handlePartialResultProgressNotification(progressParams);
-//
-//                verifyNoInteractions(lspEncryptionManager);
-//                verifyNoInteractions(jsonHandler);
-//            }
-//        }
-//
-//        @Test
-//        void testWithEmptyTabId() {
-//            try (MockedStatic<ProgressNotificationUtils> progressNotificationUtilsMock = mockStatic(ProgressNotificationUtils.class)) {
-//                progressNotificationUtilsMock
-//                        .when(() -> ProgressNotificationUtils.getToken(any(ProgressParams.class)))
-//                        .thenReturn("token");
-//                when(chatPartialResultMap.getValue(any(String.class))).thenReturn("");
-//
-//                chatCommunicationManager.handlePartialResultProgressNotification(progressParams);
-//
-//                verifyNoInteractions(lspEncryptionManager);
-//                verifyNoInteractions(jsonHandler);
-//            }
-//        }
-//
-//        @Test
-//        void testIncorrectParamsObject() {
-//            try (MockedStatic<ProgressNotificationUtils> progressNotificationUtilsMock = mockStatic(ProgressNotificationUtils.class)) {
-//                progressNotificationUtilsMock
-//                        .when(() -> ProgressNotificationUtils.getToken(any(ProgressParams.class)))
-//                        .thenReturn("token");
-//                when(chatPartialResultMap.getValue(any(String.class))).thenReturn("tabId");
-//
-//                Either<WorkDoneProgressNotification, Object> either = mock(Either.class);
-//                when(either.isLeft()).thenReturn(true);
-//                when(progressParams.getValue()).thenReturn(either);
-//
-//                assertThrows(AmazonQPluginException.class, () -> chatCommunicationManager.handlePartialResultProgressNotification(progressParams));
-//
-//                verifyNoInteractions(lspEncryptionManager);
-//                verifyNoInteractions(jsonHandler);
-//                verifyNoInteractions(chatUiRequestListener);
-//            }
-//        }
-//
-//        @Test
-//        void testIncorrectChatPartialResult() {
-//            try (MockedStatic<ProgressNotificationUtils> progressNotificationUtilsMock = mockStatic(ProgressNotificationUtils.class)) {
-//                progressNotificationUtilsMock
-//                        .when(() -> ProgressNotificationUtils.getToken(any(ProgressParams.class)))
-//                        .thenReturn("token");
-//                when(chatPartialResultMap.getValue(any(String.class))).thenReturn("tabId");
-//
-//                Either<WorkDoneProgressNotification, Object> either = mock(Either.class);
-//                when(either.getRight()).thenReturn(new Object());
-//                when(progressParams.getValue()).thenReturn(either);
-//
-//                progressNotificationUtilsMock
-//                    .when(() -> ProgressNotificationUtils.getObject(any(ProgressParams.class), eq(String.class)))
-//                    .thenReturn("chatPartialResult");
-//
-//                ChatResult chatResult = mock(ChatResult.class);
-//
-//                when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class))).thenReturn(chatResult);
-//                when(chatResult.body()).thenReturn(null);
-//
-//                chatCommunicationManager.handlePartialResultProgressNotification(progressParams);
-//
-//                verifyNoInteractions(chatUiRequestListener);
-//            }
-//        }
-//
-//        @Test
-//        void testChatPartialResult() {
-//            try (MockedStatic<ProgressNotificationUtils> progressNotificationUtilsMock = mockStatic(ProgressNotificationUtils.class)) {
-//                progressNotificationUtilsMock
-//                        .when(() -> ProgressNotificationUtils.getToken(any(ProgressParams.class)))
-//                        .thenReturn("token");
-//                when(chatPartialResultMap.getValue(any(String.class))).thenReturn("tabId");
-//
-//                Either<WorkDoneProgressNotification, Object> either = mock(Either.class);
-//                when(either.getRight()).thenReturn(new Object());
-//                when(progressParams.getValue()).thenReturn(either);
-//
-//                progressNotificationUtilsMock
-//                    .when(() -> ProgressNotificationUtils.getObject(any(ProgressParams.class), eq(String.class)))
-//                    .thenReturn("chatPartialResult");
-//
-//                ChatResult chatResult = mock(ChatResult.class);
-//
-//                when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class))).thenReturn(chatResult);
-//                when(chatResult.body()).thenReturn("body");
-//                when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
-//
-//                chatCommunicationManager.handlePartialResultProgressNotification(progressParams);
-//
-//                verify(chatUiRequestListener).onSendToChatUi("serializedObject");
-//            }
-//        }
-//
-//    }
-//
-//    @Test
-//    void sendMessageToChatServerFails() {
-//        when(jsonHandler.convertObject(any(Object.class), eq(ChatRequestParams.class)))
-//                .thenThrow(new RuntimeException("Test exception"));
-//
-//        try (MockedStatic<Display> displayMock = mockStatic(Display.class)) {
-//            displayMock.when(Display::getDefault).thenReturn(display);
-//            assertThrows(AmazonQPluginException.class, () -> chatCommunicationManager.sendMessageToChatServer(Command.CHAT_SEND_PROMPT, new Object()));
-//        }
-//    }
-//
-//}
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.chat;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.ProgressParams;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.WorkDoneProgressNotification;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.swt.widgets.Display;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+
+import software.aws.toolkits.eclipse.amazonq.broker.EventBroker;
+import software.aws.toolkits.eclipse.amazonq.chat.models.ChatItemAction;
+import software.aws.toolkits.eclipse.amazonq.chat.models.ChatPrompt;
+import software.aws.toolkits.eclipse.amazonq.chat.models.ChatRequestParams;
+import software.aws.toolkits.eclipse.amazonq.chat.models.ChatResult;
+import software.aws.toolkits.eclipse.amazonq.chat.models.ChatUIInboundCommand;
+import software.aws.toolkits.eclipse.amazonq.chat.models.CursorState;
+import software.aws.toolkits.eclipse.amazonq.chat.models.EncryptedChatParams;
+import software.aws.toolkits.eclipse.amazonq.chat.models.EncryptedQuickActionParams;
+import software.aws.toolkits.eclipse.amazonq.chat.models.FeedbackParams;
+import software.aws.toolkits.eclipse.amazonq.chat.models.FeedbackPayload;
+import software.aws.toolkits.eclipse.amazonq.chat.models.FollowUp;
+import software.aws.toolkits.eclipse.amazonq.chat.models.FollowUpClickParams;
+import software.aws.toolkits.eclipse.amazonq.chat.models.GenericTabParams;
+import software.aws.toolkits.eclipse.amazonq.chat.models.QuickActionParams;
+import software.aws.toolkits.eclipse.amazonq.chat.models.RecommendationContentSpan;
+import software.aws.toolkits.eclipse.amazonq.chat.models.ReferenceTrackerInformation;
+import software.aws.toolkits.eclipse.amazonq.chat.models.RelatedContent;
+import software.aws.toolkits.eclipse.amazonq.chat.models.SourceLink;
+import software.aws.toolkits.eclipse.amazonq.exception.AmazonQPluginException;
+import software.aws.toolkits.eclipse.amazonq.extensions.implementation.ActivatorStaticMockExtension;
+import software.aws.toolkits.eclipse.amazonq.lsp.encryption.LspEncryptionManager;
+import software.aws.toolkits.eclipse.amazonq.util.CodeReferenceLoggingService;
+import software.aws.toolkits.eclipse.amazonq.util.JsonHandler;
+import software.aws.toolkits.eclipse.amazonq.util.LoggingService;
+import software.aws.toolkits.eclipse.amazonq.util.ProgressNotificationUtils;
+import software.aws.toolkits.eclipse.amazonq.views.model.ChatCodeReference;
+import software.aws.toolkits.eclipse.amazonq.views.model.Command;
+
+public final class ChatCommunicationManagerTest {
+
+    @Mock
+    private JsonHandler jsonHandler;
+
+    @Mock
+    private LspEncryptionManager lspEncryptionManager;
+
+    @Mock
+    private ChatMessageProvider chatMessageProvider;
+
+    @Mock
+    private CompletableFuture<ChatMessageProvider> chatMessageProviderFuture;
+
+    @Mock
+    private ChatPartialResultMap chatPartialResultMap;
+
+    @Mock
+    private Display display;
+
+    private ChatCommunicationManager chatCommunicationManager;
+
+
+    @BeforeEach
+    void setupBeforeEach() {
+        MockitoAnnotations.openMocks(this);
+        // Make sure thenAcceptAsync runs on the main thread
+        doAnswer(invocation -> {
+            Consumer<? super ChatMessageProvider> consumer = invocation.getArgument(0);
+            consumer.accept(chatMessageProvider);
+            return CompletableFuture.completedFuture(null);
+        }).when(chatMessageProviderFuture).thenAcceptAsync(ArgumentMatchers.<Consumer<? super ChatMessageProvider>>any(), any());
+
+        chatCommunicationManager = spy(ChatCommunicationManager.builder()
+                .withJsonHandler(jsonHandler)
+                .withLspEncryptionManager(lspEncryptionManager)
+                .withChatMessageProvider(chatMessageProviderFuture)
+                .withChatPartialResultMap(chatPartialResultMap)
+                .build());
+
+        when(lspEncryptionManager.encrypt(any(String.class))).thenReturn("encrypted-message");
+        when(lspEncryptionManager.decrypt(any(String.class))).thenReturn("decrypted response");
+
+    }
+
+    @Nested
+    class SendChatPromptTests {
+
+        @RegisterExtension
+        private static ActivatorStaticMockExtension activatorStaticMockExtension = new ActivatorStaticMockExtension();
+
+        private final CursorState cursorState = new CursorState(new Range(new Position(0, 0), new Position(1, 1)));
+
+        private final ChatRequestParams params = new ChatRequestParams(
+            "tabId",
+            new ChatPrompt("prompt", "escaped prompt", "command", null),
+            new TextDocumentIdentifier("textDocument"),
+                Arrays.asList(cursorState), null
+        );
+
+        private final ChatItemAction chatItemAction = new ChatItemAction(
+            "pillText", "prompt", false, "description", "button"
+        );
+
+        private final ReferenceTrackerInformation referenceTracker = new ReferenceTrackerInformation(
+            "licenseName",
+            "repository",
+            "url",
+            new RecommendationContentSpan(1, 2),
+            "information"
+        );
+
+        private final ChatResult chatResult = new ChatResult(
+            "body",
+            "messageId",
+            true,
+            new RelatedContent("title", new SourceLink[]{new SourceLink("title", "url", "body")}),
+            new FollowUp("text", new ChatItemAction[]{chatItemAction}),
+            new ReferenceTrackerInformation[]{referenceTracker}
+        );
+
+        private CodeReferenceLoggingService codeReferenceLoggingService;
+
+        @BeforeEach
+        void setupBeforeEach() {
+            codeReferenceLoggingService = activatorStaticMockExtension.getMock(CodeReferenceLoggingService.class);
+            doReturn(Optional.of("fileUri")).when(chatCommunicationManager).getOpenFileUri();
+            doReturn(Optional.of(cursorState)).when(chatCommunicationManager).getSelectionRangeCursorState();
+        }
+
+        @Test
+        void testChatSendPrompt() {
+            when(jsonHandler.convertObject(any(Object.class), eq(ChatRequestParams.class)))
+                    .thenReturn(params);
+            when(chatMessageProvider.sendChatPrompt(any(String.class), any(EncryptedChatParams.class)))
+                    .thenReturn(CompletableFuture.completedFuture("chat response"));
+
+            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
+                    .thenReturn(chatResult);
+            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
+
+            try (MockedStatic<Display> displayMock = mockStatic(Display.class)) {
+                displayMock.when(Display::getDefault).thenReturn(display);
+                chatCommunicationManager.sendMessageToChatServer(Command.CHAT_SEND_PROMPT, params);
+            }
+
+            verify(jsonHandler).convertObject(any(Object.class), eq(ChatRequestParams.class));
+            verify(chatPartialResultMap).setEntry(any(String.class), eq("tabId"));
+            verify(chatPartialResultMap).removeEntry(any(String.class));
+
+            verify(lspEncryptionManager).encrypt(params);
+            verify(chatMessageProvider).sendChatPrompt(eq("tabId"), any(EncryptedChatParams.class));
+            verify(activatorStaticMockExtension.getMock(EventBroker.class)).post(eq(ChatUIInboundCommand.class),
+                    any(ChatUIInboundCommand.class));
+            verify(codeReferenceLoggingService).log(any(ChatCodeReference.class));
+        }
+
+        @Test
+        void testChatSendPromptWithErrorCommunicatingWithServer() {
+            when(jsonHandler.convertObject(any(Object.class), eq(ChatRequestParams.class)))
+                    .thenReturn(params);
+            when(chatMessageProvider.sendChatPrompt(any(String.class), any(EncryptedChatParams.class)))
+                    .thenReturn(CompletableFuture.failedFuture(new RuntimeException("error message")));
+            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
+                    .thenReturn(chatResult);
+            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
+
+            try (MockedStatic<Display> displayMock = mockStatic(Display.class)) {
+                displayMock.when(Display::getDefault).thenReturn(display);
+                chatCommunicationManager.sendMessageToChatServer(Command.CHAT_SEND_PROMPT, params);
+            }
+
+            verify(activatorStaticMockExtension.getMock(EventBroker.class)).post(eq(ChatUIInboundCommand.class),
+                    any(ChatUIInboundCommand.class));
+            verify(activatorStaticMockExtension.getMock(LoggingService.class)).error(argThat(message ->
+                message.contains("An error occurred while processing chat request")));
+        }
+
+        @Test
+        void testChatSendPromptWithErrorInResponse() {
+            when(jsonHandler.convertObject(any(Object.class), eq(ChatRequestParams.class)))
+                    .thenReturn(params);
+            when(chatMessageProvider.sendChatPrompt(any(String.class), any(EncryptedChatParams.class)))
+                    .thenReturn(CompletableFuture.completedFuture("chat response"));
+            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
+                    .thenThrow(new RuntimeException("Test exception"));
+            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
+
+            try (MockedStatic<Display> displayMock = mockStatic(Display.class)) {
+                displayMock.when(Display::getDefault).thenReturn(display);
+                chatCommunicationManager.sendMessageToChatServer(Command.CHAT_SEND_PROMPT, params);
+            }
+
+            verify(activatorStaticMockExtension.getMock(EventBroker.class)).post(eq(ChatUIInboundCommand.class),
+                    any(ChatUIInboundCommand.class));
+            verify(activatorStaticMockExtension.getMock(LoggingService.class)).error(argThat(message ->
+                message.contains("An error occurred while processing chat response")));
+        }
+
+    }
+
+    @Nested
+    class SendQuickActionsTests {
+
+        @RegisterExtension
+        private static ActivatorStaticMockExtension activatorStaticMockExtension = new ActivatorStaticMockExtension();
+
+        private final QuickActionParams quickActionParams = new QuickActionParams("tabId", "quickAction", "prompt");
+
+        private final ChatItemAction chatItemAction = new ChatItemAction(
+            "pillText", "prompt", false, "description", "button"
+        );
+
+        private final ReferenceTrackerInformation referenceTracker = new ReferenceTrackerInformation(
+            "licenseName",
+            "repository",
+            "url",
+            new RecommendationContentSpan(1, 2),
+            "information"
+        );
+
+        private final ChatResult chatResult = new ChatResult(
+                "body",
+                "messageId",
+                true,
+                new RelatedContent("title", new SourceLink[]{new SourceLink("title", "url", "body")}),
+                new FollowUp("text", new ChatItemAction[]{chatItemAction}),
+                new ReferenceTrackerInformation[]{referenceTracker}
+            );
+
+        @Test
+        void testSendQuickAction() {
+            when(jsonHandler.convertObject(any(Object.class), eq(QuickActionParams.class)))
+                    .thenReturn(quickActionParams);
+            when(chatMessageProvider.sendQuickAction(any(String.class), any(EncryptedQuickActionParams.class)))
+                    .thenReturn(CompletableFuture.completedFuture("chat response"));
+
+            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
+                    .thenReturn(chatResult);
+            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
+
+            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_QUICK_ACTION, quickActionParams);
+
+            verify(jsonHandler).convertObject(any(Object.class), eq(QuickActionParams.class));
+            verify(chatPartialResultMap).setEntry(any(String.class), eq("tabId"));
+            verify(chatPartialResultMap).removeEntry(any(String.class));
+
+            verify(lspEncryptionManager).encrypt(quickActionParams);
+            verify(chatMessageProvider).sendQuickAction(eq("tabId"), any(EncryptedQuickActionParams.class));
+            verify(activatorStaticMockExtension.getMock(EventBroker.class)).post(eq(ChatUIInboundCommand.class),
+                    any(ChatUIInboundCommand.class));
+        }
+
+        @Test
+        void testChatSendPromptWithErrorCommunicatingWithServer() {
+            when(jsonHandler.convertObject(any(Object.class), eq(QuickActionParams.class)))
+                    .thenReturn(quickActionParams);
+            when(chatMessageProvider.sendQuickAction(any(String.class), any(EncryptedQuickActionParams.class)))
+                    .thenReturn(CompletableFuture.failedFuture(new RuntimeException("error message")));
+
+            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
+                    .thenReturn(chatResult);
+            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
+
+            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_QUICK_ACTION, quickActionParams);
+
+            verify(activatorStaticMockExtension.getMock(EventBroker.class)).post(eq(ChatUIInboundCommand.class),
+                    any(ChatUIInboundCommand.class));
+            verify(activatorStaticMockExtension.getMock(LoggingService.class)).error(argThat(message ->
+                message.contains("An error occurred while processing chat request")));
+        }
+
+        @Test
+        void testChatSendPromptWithErrorInResponse() {
+            when(jsonHandler.convertObject(any(Object.class), eq(QuickActionParams.class)))
+                    .thenReturn(quickActionParams);
+            when(chatMessageProvider.sendQuickAction(any(String.class), any(EncryptedQuickActionParams.class)))
+                    .thenReturn(CompletableFuture.completedFuture("chat response"));
+
+            when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class)))
+                    .thenThrow(new RuntimeException("Test exception"));
+            when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
+
+            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_QUICK_ACTION, quickActionParams);
+
+            verify(activatorStaticMockExtension.getMock(EventBroker.class)).post(eq(ChatUIInboundCommand.class),
+                    any(ChatUIInboundCommand.class));
+            verify(activatorStaticMockExtension.getMock(LoggingService.class)).error(argThat(message ->
+                message.contains("An error occurred while processing chat response")));
+        }
+
+    }
+
+    @Nested
+    class SendChatReadyAndTelemetryEventTests {
+
+        @Test
+        void testSendQuickAction() {
+            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_READY, new Object());
+            verify(chatMessageProvider).sendChatReady();
+        }
+
+        @Test
+        void testTelemetryEvent() {
+            chatCommunicationManager.sendMessageToChatServer(Command.TELEMETRY_EVENT, new Object());
+            verify(chatMessageProvider).sendTelemetryEvent(any(Object.class));
+        }
+
+    }
+
+    @Nested
+    class SendTabUpdateTests {
+
+        private final GenericTabParams genericTabParams = new GenericTabParams("tabId");
+
+        @BeforeEach
+        void setupBeforeEach() {
+            when(jsonHandler.convertObject(any(Object.class), eq(GenericTabParams.class)))
+                    .thenReturn(genericTabParams);
+        }
+
+        @Test
+        void testChatTabAdd() {
+            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_TAB_ADD, genericTabParams);
+            verify(chatMessageProvider).sendTabAdd(genericTabParams);
+        }
+
+        @Test
+        void testChatTabRemove() {
+            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_TAB_REMOVE, genericTabParams);
+            verify(chatMessageProvider).sendTabRemove(genericTabParams);
+        }
+
+        @Test
+        void testChatTabChange() {
+            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_TAB_CHANGE, genericTabParams);
+            verify(chatMessageProvider).sendTabChange(genericTabParams);
+        }
+
+        @Test
+        void testEndChat() {
+            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_END_CHAT, genericTabParams);
+            verify(chatMessageProvider).endChat(genericTabParams);
+        }
+
+    }
+
+    @Nested
+    class SendFollowUpClickTests {
+
+        private final ChatItemAction chatItemAction = new ChatItemAction(
+            "pillText", "prompt", false, "description", "button"
+        );
+
+        private final FollowUpClickParams followUpClickParams = new FollowUpClickParams("tabId", "messageId", chatItemAction);
+
+        @BeforeEach
+        void setupBeforeEach() {
+            when(jsonHandler.convertObject(any(Object.class), eq(FollowUpClickParams.class)))
+                    .thenReturn(followUpClickParams);
+        }
+
+        @Test
+        void testFollowUpClick() {
+            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_FOLLOW_UP_CLICK, followUpClickParams);
+            verify(chatMessageProvider).followUpClick(followUpClickParams);
+        }
+
+    }
+
+    @Nested
+    class SendFeedbackTests {
+
+        private final FeedbackPayload feedbackPayload = new FeedbackPayload("messageId", "tabId", "selectedOption", "commend");
+        private final FeedbackParams feedbackParams = new FeedbackParams("tabId", "eventId", feedbackPayload);
+
+        @BeforeEach
+        void setupBeforeEach() {
+            when(jsonHandler.convertObject(any(Object.class), eq(FeedbackParams.class)))
+                    .thenReturn(feedbackParams);
+        }
+
+        @Test
+        void testFollowUpClick() {
+            chatCommunicationManager.sendMessageToChatServer(Command.CHAT_FEEDBACK, feedbackParams);
+            verify(chatMessageProvider).sendFeedback(feedbackParams);
+        }
+
+    }
+
+    @Nested
+    class HandlePartialResultProgressNotificationTests {
+
+        @RegisterExtension
+        private static ActivatorStaticMockExtension activatorStaticMockExtension = new ActivatorStaticMockExtension();
+
+        @Mock
+        private ProgressParams progressParams;
+
+        @BeforeEach
+        void setupBeforeEach() {
+            MockitoAnnotations.openMocks(this);
+        }
+
+        @Test
+        void testWithNullTabId() {
+            try (MockedStatic<ProgressNotificationUtils> progressNotificationUtilsMock = mockStatic(ProgressNotificationUtils.class)) {
+                progressNotificationUtilsMock
+                        .when(() -> ProgressNotificationUtils.getToken(any(ProgressParams.class)))
+                        .thenReturn("token");
+                when(chatPartialResultMap.getValue(any(String.class))).thenReturn(null);
+
+                chatCommunicationManager.handlePartialResultProgressNotification(progressParams);
+
+                verifyNoInteractions(lspEncryptionManager);
+                verifyNoInteractions(jsonHandler);
+                verifyNoInteractions(activatorStaticMockExtension.getMock(EventBroker.class));
+            }
+        }
+
+        @Test
+        void testWithEmptyTabId() {
+            try (MockedStatic<ProgressNotificationUtils> progressNotificationUtilsMock = mockStatic(ProgressNotificationUtils.class)) {
+                progressNotificationUtilsMock
+                        .when(() -> ProgressNotificationUtils.getToken(any(ProgressParams.class)))
+                        .thenReturn("token");
+                when(chatPartialResultMap.getValue(any(String.class))).thenReturn("");
+
+                chatCommunicationManager.handlePartialResultProgressNotification(progressParams);
+
+                verifyNoInteractions(lspEncryptionManager);
+                verifyNoInteractions(jsonHandler);
+                verifyNoInteractions(activatorStaticMockExtension.getMock(EventBroker.class));
+            }
+        }
+
+        @Test
+        void testIncorrectParamsObject() {
+            try (MockedStatic<ProgressNotificationUtils> progressNotificationUtilsMock = mockStatic(ProgressNotificationUtils.class)) {
+                progressNotificationUtilsMock
+                        .when(() -> ProgressNotificationUtils.getToken(any(ProgressParams.class)))
+                        .thenReturn("token");
+                when(chatPartialResultMap.getValue(any(String.class))).thenReturn("tabId");
+
+                Either<WorkDoneProgressNotification, Object> either = mock(Either.class);
+                when(either.isLeft()).thenReturn(true);
+                when(progressParams.getValue()).thenReturn(either);
+
+                assertThrows(AmazonQPluginException.class, () -> chatCommunicationManager.handlePartialResultProgressNotification(progressParams));
+
+                verifyNoInteractions(lspEncryptionManager);
+                verifyNoInteractions(jsonHandler);
+                verifyNoInteractions(activatorStaticMockExtension.getMock(EventBroker.class));
+            }
+        }
+
+        @Test
+        void testIncorrectChatPartialResult() {
+            try (MockedStatic<ProgressNotificationUtils> progressNotificationUtilsMock = mockStatic(ProgressNotificationUtils.class)) {
+                progressNotificationUtilsMock
+                        .when(() -> ProgressNotificationUtils.getToken(any(ProgressParams.class)))
+                        .thenReturn("token");
+                when(chatPartialResultMap.getValue(any(String.class))).thenReturn("tabId");
+
+                Either<WorkDoneProgressNotification, Object> either = mock(Either.class);
+                when(either.getRight()).thenReturn(new Object());
+                when(progressParams.getValue()).thenReturn(either);
+
+                progressNotificationUtilsMock
+                    .when(() -> ProgressNotificationUtils.getObject(any(ProgressParams.class), eq(String.class)))
+                    .thenReturn("chatPartialResult");
+
+                ChatResult chatResult = mock(ChatResult.class);
+
+                when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class))).thenReturn(chatResult);
+                when(chatResult.body()).thenReturn(null);
+
+                chatCommunicationManager.handlePartialResultProgressNotification(progressParams);
+
+                verifyNoInteractions(activatorStaticMockExtension.getMock(EventBroker.class));
+            }
+        }
+
+        @Test
+        void testChatPartialResult() {
+            try (MockedStatic<ProgressNotificationUtils> progressNotificationUtilsMock = mockStatic(ProgressNotificationUtils.class)) {
+                progressNotificationUtilsMock
+                        .when(() -> ProgressNotificationUtils.getToken(any(ProgressParams.class)))
+                        .thenReturn("token");
+                when(chatPartialResultMap.getValue(any(String.class))).thenReturn("tabId");
+
+                Either<WorkDoneProgressNotification, Object> either = mock(Either.class);
+                when(either.getRight()).thenReturn(new Object());
+                when(progressParams.getValue()).thenReturn(either);
+
+                progressNotificationUtilsMock
+                    .when(() -> ProgressNotificationUtils.getObject(any(ProgressParams.class), eq(String.class)))
+                    .thenReturn("chatPartialResult");
+
+                ChatResult chatResult = mock(ChatResult.class);
+
+                when(jsonHandler.deserialize(any(String.class), eq(ChatResult.class))).thenReturn(chatResult);
+                when(chatResult.body()).thenReturn("body");
+                when(jsonHandler.serialize(any(ChatUIInboundCommand.class))).thenReturn("serializedObject");
+
+                chatCommunicationManager.handlePartialResultProgressNotification(progressParams);
+
+                verify(activatorStaticMockExtension.getMock(EventBroker.class)).post(eq(ChatUIInboundCommand.class),
+                        any(ChatUIInboundCommand.class));
+            }
+        }
+
+    }
+
+    @Test
+    void sendMessageToChatServerFails() {
+        when(jsonHandler.convertObject(any(Object.class), eq(ChatRequestParams.class)))
+                .thenThrow(new RuntimeException("Test exception"));
+
+        try (MockedStatic<Display> displayMock = mockStatic(Display.class)) {
+            displayMock.when(Display::getDefault).thenReturn(display);
+            assertThrows(AmazonQPluginException.class, () -> chatCommunicationManager.sendMessageToChatServer(Command.CHAT_SEND_PROMPT, new Object()));
+        }
+    }
+
+}

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManagerTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManagerTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -121,9 +122,10 @@ public final class ChatCommunicationManagerTest {
 
         private final ChatRequestParams params = new ChatRequestParams(
             "tabId",
-            new ChatPrompt("prompt", "escaped prompt", "command", null),
+            new ChatPrompt("prompt", "escaped prompt", "command", Collections.emptyList()),
             new TextDocumentIdentifier("textDocument"),
-                Arrays.asList(cursorState), null
+            Arrays.asList(cursorState), 
+            Collections.emptyList()
         );
 
         private final ChatItemAction chatItemAction = new ChatItemAction(


### PR DESCRIPTION
*Description of changes:*
- Make event broker replayable for partial response streaming in after chat webview is disposed.

*Demo:*
![ScreenRecording2025-04-30at11 33 33AM-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/6bcff80f-0ed8-4d33-afe1-1abe6ac2bb0d)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
