### PR TITLE
Add model selection UI feature to Amazon Q for Eclipse

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
@@ -532,6 +532,7 @@ public final class ChatCommunicationManager implements EventObserver<ChatUIInbou
      */
     private void sendMessageToChatUI(final ChatUIInboundCommand command) {
         String message = jsonHandler.serialize(command);
+        
         String inlineChatCommand = ChatUIInboundCommandName.InlineChatPrompt.getValue();
         if (inlineChatCommand.equals(command.command())) {
             inlineChatListenerFuture.thenApply(listener -> {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/models/ChatUIInboundCommandName.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/models/ChatUIInboundCommandName.java
@@ -12,7 +12,8 @@ public enum ChatUIInboundCommandName {
     ErrorMessage("errorMessage"),
     InsertToCursorPosition("insertToCursorPosition"),
     AuthFollowUpClicked("authFollowUpClicked"),
-    GenericCommand("genericCommand");
+    GenericCommand("genericCommand"),
+    ChatOptionsUpdate("aws/chat/chatOptionsUpdate");
 
     private final String value;
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspClient.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspClient.java
@@ -43,6 +43,9 @@ public interface AmazonQLspClient extends LanguageClient {
     @JsonNotification("aws/chat/sendChatUpdate")
     void sendChatUpdate(Object params);
 
+    @JsonNotification("aws/chat/chatOptionsUpdate")
+    void chatOptionsUpdate(Object params);
+
     @JsonNotification("aws/didCopyFile")
     void didCopyFile(Object params);
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspClientImpl.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspClientImpl.java
@@ -517,6 +517,13 @@ public class AmazonQLspClientImpl extends LanguageClientImpl implements AmazonQL
     }
 
     @Override
+    public final void chatOptionsUpdate(final Object params) {
+        var chatOptionsUpdateCommand = new ChatUIInboundCommand("aws/chat/chatOptionsUpdate", null, params,
+                false, null);
+        Activator.getEventBroker().post(ChatUIInboundCommand.class, chatOptionsUpdateCommand);
+    }
+
+    @Override
     public final void didCopyFile(final Object params) {
         refreshProjects();
     }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/assets/ChatWebViewAssetProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/assets/ChatWebViewAssetProvider.java
@@ -165,7 +165,8 @@ public final class ChatWebViewAssetProvider extends WebViewAssetProvider {
                                 {
                                     disclaimerAcknowledged: %b,
                                     pairProgrammingAcknowledged: %b,
-                                    agenticMode: true
+                                    agenticMode: true,
+                                    modelSelectionEnabled: true
                                 });
                                 window.mynah = mynahUI
                             })


### PR DESCRIPTION
This change adds support for model selection in the Amazon Q chat interface by:
1. Adding modelSelectionEnabled flag to the UI configuration
2. Adding ChatOptionsUpdate command type for model selection communication
3. Implementing handlers for model selection updates
4. Removing development logging and debug paths




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
