### PR TITLE
Add font size conditional based on user platform

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/ChangeProfileDialog.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/ChangeProfileDialog.java
@@ -45,6 +45,9 @@ public final class ChangeProfileDialog extends Dialog {
     private RadioButtonWithDescriptor selectedRadioButton;
     private Font loadingLabelFont;
     private Font scrollableLabelFont;
+    private final int smallFont = PluginUtils.getPlatform().equals(PluginPlatform.WINDOWS) ? 8 : 12;
+    private final int mediumFont = PluginUtils.getPlatform().equals(PluginPlatform.WINDOWS) ? 10 : 14;
+    private final int largeFont = PluginUtils.getPlatform().equals(PluginPlatform.WINDOWS) ? 12 : 16;
 
     public final class RadioButtonWithDescriptor extends Composite {
 
@@ -75,8 +78,8 @@ public final class ChangeProfileDialog extends Dialog {
             radioButton = new Button(topRow, SWT.RADIO | style);
             radioButton.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
 
-            profileNameFont = createFont(12, SWT.NORMAL);
-            regionFont = createFont(12, SWT.ITALIC);
+            profileNameFont = createFont(smallFont, SWT.NORMAL);
+            regionFont = createFont(smallFont, SWT.ITALIC);
 
             profileNameAndRegionText = new StyledText(topRow, SWT.READ_ONLY);
             profileNameAndRegionText.setText(profileName + " - " + region);
@@ -231,7 +234,7 @@ public final class ChangeProfileDialog extends Dialog {
         scrollableLabelData.verticalIndent = 0;
         scrollableLabel.setLayoutData(scrollableLabelData);
 
-        scrollableLabelFont = createFont(16, SWT.BOLD);
+        scrollableLabelFont = createFont(largeFont, SWT.BOLD);
         scrollableLabel.setFont(scrollableLabelFont);
 
         Runnable showDownArrowWhenScrollable = new Runnable() {
@@ -270,14 +273,14 @@ public final class ChangeProfileDialog extends Dialog {
     }
 
     private void setupHeaderText(final Composite container) {
-        titleFont = createFont(14, SWT.BOLD);
+        titleFont = createFont(mediumFont, SWT.BOLD);
 
         Label headerLabel = new Label(container, SWT.NONE);
         headerLabel.setText(HEADER);
         headerLabel.setFont(titleFont);
         headerLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 
-        descriptionFont = createFont(12, SWT.NORMAL);
+        descriptionFont = createFont(smallFont, SWT.NORMAL);
 
         StyledText descriptionText = new StyledText(container, SWT.READ_ONLY | SWT.WRAP);
         descriptionText.setText(DESCRIPTION);
@@ -296,7 +299,7 @@ public final class ChangeProfileDialog extends Dialog {
         loadingLabel.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, true, true));
         loadingLabel.setText("Loading profiles   ");
 
-        loadingLabelFont = createFont(11, SWT.ITALIC);
+        loadingLabelFont = createFont(smallFont, SWT.ITALIC);
         loadingLabel.setFont(loadingLabelFont);
 
         Point size = loadingLabel.computeSize(SWT.DEFAULT, SWT.DEFAULT);

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/CustomizationDialog.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/CustomizationDialog.java
@@ -47,6 +47,8 @@ public final class CustomizationDialog extends Dialog {
     private List<Customization> customizationsResponse;
     private ResponseSelection responseSelection;
     private Customization selectedCustomization;
+    private final int smallFont = PluginUtils.getPlatform().equals(PluginPlatform.WINDOWS) ? 8 : 12;
+    private final int mediumFont = PluginUtils.getPlatform().equals(PluginPlatform.WINDOWS) ? 10 : 14;
 
     public enum ResponseSelection {
         AMAZON_Q_FOUNDATION_DEFAULT,
@@ -81,7 +83,7 @@ public final class CustomizationDialog extends Dialog {
             radioButton = new Button(topRow, SWT.RADIO | style);
             radioButton.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
 
-            textFont = createFont(12, SWT.NORMAL);
+            textFont = createFont(smallFont, SWT.NORMAL);
 
             textLabel = new Label(topRow, SWT.WRAP);
             textLabel.setText(text);
@@ -90,7 +92,7 @@ public final class CustomizationDialog extends Dialog {
             textData.horizontalIndent = PluginUtils.getPlatform().equals(PluginPlatform.WINDOWS) ? 3 : 0;
             textLabel.setLayoutData(textData);
 
-            subtextFont = createFont(11, SWT.ITALIC);
+            subtextFont = createFont(smallFont, SWT.ITALIC);
 
             subtextLabel = new Label(this, SWT.WRAP);
             subtextLabel.setText(subtext);
@@ -243,7 +245,7 @@ public final class CustomizationDialog extends Dialog {
         mainLayout.verticalSpacing = 10;
         container.setLayout(mainLayout);
 
-        titleFont = createFont(14, SWT.BOLD);
+        titleFont = createFont(mediumFont, SWT.BOLD);
 
         Label titleLabel = new Label(container, SWT.NONE);
         titleLabel.setText("Select an Amazon Q Customization");


### PR DESCRIPTION
*Description of changes:*
Font sizes were rendering in too large on windows machines, causing content in the profile selection window to get pushed off screen and below the visible window. This change uses appropriate font sizes based on the OS platform the user is on.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
