### PR TITLE
Handle race condition for view computed prior to container being alive

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
@@ -81,7 +81,6 @@ public final class ChatCommunicationManager implements EventObserver<ChatUIInbou
 
     private volatile boolean isActive = false;
     private volatile boolean isQueueProcessorRunning = false;
-    private volatile boolean isChatReady = false;
     private volatile Thread queueProcessorThread;
 
     private final String inlineChatTabId = "123456789";
@@ -116,7 +115,7 @@ public final class ChatCommunicationManager implements EventObserver<ChatUIInbou
     public void sendMessageToChatServer(final Command command, final ChatMessage message) {
         Activator.getLspProvider().getAmazonQServer().thenAcceptAsync(amazonQLspServer -> {
             try {
-                if (isChatReady && (!isQueueProcessorRunning || (queueProcessorThread != null && !queueProcessorThread.isAlive()))) {
+                if (!isQueueProcessorRunning || (queueProcessorThread != null && !queueProcessorThread.isAlive())) {
                     isQueueProcessorRunning = false;
                     startCommandQueueProcessor();
                 }
@@ -149,10 +148,7 @@ public final class ChatCommunicationManager implements EventObserver<ChatUIInbou
                         });
                         break;
                     case CHAT_READY:
-                        if (!isChatReady) {
-                            amazonQLspServer.chatReady();
-                            isChatReady = true;
-                        }
+                        amazonQLspServer.chatReady();
                         startCommandQueueProcessor();
                         break;
                     case CHAT_TAB_ADD:

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQViewContainer.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQViewContainer.java
@@ -27,6 +27,7 @@ public final class AmazonQViewContainer extends ViewPart implements EventObserve
     private volatile StackLayout layout;
     private volatile AmazonQViewType activeViewType;
     private volatile BaseAmazonQView currentView;
+    private volatile AmazonQViewType queuedViewType;
 
     static {
         VIEWS = Map.of(AmazonQViewType.CHAT_ASSET_MISSING_VIEW, new ChatAssetMissingView(),
@@ -53,6 +54,12 @@ public final class AmazonQViewContainer extends ViewPart implements EventObserve
         parent.setLayout(gridLayout);
 
         parentComposite = parent;
+
+        if (queuedViewType != null) {
+            AmazonQViewType viewType = queuedViewType;
+            queuedViewType = null;
+            onEvent(viewType);
+        }
     }
 
     private void updateChildView() {
@@ -92,11 +99,13 @@ public final class AmazonQViewContainer extends ViewPart implements EventObserve
             return;
         }
 
-        activeViewType = newViewType;
-
-        if (parentComposite != null && !parentComposite.isDisposed()) {
-            updateChildView();
+        if (parentComposite == null || parentComposite.isDisposed()) {
+            queuedViewType = newViewType;
+            return;
         }
+
+        activeViewType = newViewType;
+        updateChildView();
     }
 
     @Override


### PR DESCRIPTION
*Description of changes:*
Due to #451 it is possible for a view change event to come in prior to the view container being active, meaning the view will never get updated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
