### PR TITLE
Add Model Context Protocol (MCP) Support to Amazon Q Eclipse Plugin

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
@@ -237,6 +237,26 @@ public final class ChatCommunicationManager implements EventObserver<ChatUIInbou
                             sendErrorToUi(tabId, new Throwable(response.failureReason()));
                         }
                         break;
+                    case LIST_MCP_SERVERS:
+                        try {
+                            Object mcpServersResponse = amazonQLspServer.listMcpServers(message.getData()).get();
+                            var listMcpServersCommand = ChatUIInboundCommand.createCommand("aws/chat/listMcpServers",
+                                    mcpServersResponse);
+                            Activator.getEventBroker().post(ChatUIInboundCommand.class, listMcpServersCommand);
+                        } catch (Exception e) {
+                            Activator.getLogger().error("Error processing listMcpServers: " + e);
+                        }
+                        break;
+                    case MCP_SERVER_CLICK:
+                        try {
+                            Object mcpServerClickResponse = amazonQLspServer.mcpServerClick(message.getData()).get();
+                            var mcpServerClickCommand = ChatUIInboundCommand.createCommand("aws/chat/mcpServerClick",
+                                    mcpServerClickResponse);
+                            Activator.getEventBroker().post(ChatUIInboundCommand.class, mcpServerClickCommand);
+                        } catch (Exception e) {
+                            Activator.getLogger().error("Error processing mcpServerClick: " + e);
+                        }
+                        break;
                     default:
                         throw new AmazonQPluginException("Unexpected command received from Chat UI: " + command.toString());
                 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/models/ChatUIInboundCommandName.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/models/ChatUIInboundCommandName.java
@@ -12,7 +12,10 @@ public enum ChatUIInboundCommandName {
     ErrorMessage("errorMessage"),
     InsertToCursorPosition("insertToCursorPosition"),
     AuthFollowUpClicked("authFollowUpClicked"),
-    GenericCommand("genericCommand");
+    GenericCommand("genericCommand"),
+    ChatOptionsUpdate("aws/chat/chatOptionsUpdate"),
+    ListMcpServers("aws/chat/listMcpServers"),
+    McpServerClick("aws/chat/mcpServerClick");
 
     private final String value;
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServer.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServer.java
@@ -123,4 +123,10 @@ public interface AmazonQLspServer extends LanguageServer {
 
     @JsonRequest("aws/chat/buttonClick")
     CompletableFuture<ButtonClickResult> buttonClick(Object params);
+
+    @JsonRequest("aws/chat/listMcpServers")
+    CompletableFuture<Object> listMcpServers(Object params);
+
+    @JsonRequest("aws/chat/mcpServerClick")
+    CompletableFuture<Object> mcpServerClick(Object params);
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServerBuilder.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServerBuilder.java
@@ -55,6 +55,7 @@ public class AmazonQLspServerBuilder extends Builder<AmazonQLspServer> {
         awsInitOptions.put("clientInfo", extendedClientInfoOptions);
         qOptions.put("developerProfiles", true);
         qOptions.put("customizationsWithMetadata", true);
+        qOptions.put("mcp", true);
         awsClientCapabilities.put("q", qOptions);
         Map<String, Object> window = new HashMap<>();
         window.put("showSaveFileDialog", true);

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/model/ChatOptions.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/model/ChatOptions.java
@@ -3,4 +3,4 @@
 
 package software.aws.toolkits.eclipse.amazonq.lsp.model;
 
-public record ChatOptions(QuickActions quickActions, boolean history, boolean export) { }
+public record ChatOptions(QuickActions quickActions, boolean history, boolean export, boolean mcpServers) { }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatViewActionHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatViewActionHandler.java
@@ -67,6 +67,8 @@ public class AmazonQChatViewActionHandler implements ViewActionHandler {
             case STOP_CHAT_RESPONSE:
             case BUTTON_CLICK:
             case TAB_BAR_ACTION:
+            case LIST_MCP_SERVERS:
+            case MCP_SERVER_CLICK:
                 chatCommunicationManager.sendMessageToChatServer(command, message);
                 break;
             case CHAT_INFO_LINK_CLICK:

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/Command.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/Command.java
@@ -38,6 +38,8 @@ public enum Command {
     BUTTON_CLICK("aws/chat/buttonClick"),
     CHAT_OPEN_TAB("aws/chat/openTab"),
     OPEN_SETTINGS("openSettings"),
+    LIST_MCP_SERVERS("aws/chat/listMcpServers"),
+    MCP_SERVER_CLICK("aws/chat/mcpServerClick"),
 
     // Auth
     LOGIN_BUILDER_ID("loginBuilderId"),


### PR DESCRIPTION
## Description
Implements complete MCP integration enabling Amazon Q to interact with external MCP servers for enhanced contextual 
assistance.

Key Changes:
• Added MCP server discovery and interaction commands (listMcpServers, mcpServerClick)
• Extended chat communication flow to handle MCP-specific operations
• Enabled MCP capability in LSP server configuration
• Updated ChatOptions model to include MCP servers toggle
• Integrated MCP commands into existing chat UI command routing

This enhancement allows users to leverage external MCP servers to provide additional context and tools to Amazon Q 
conversations within Eclipse.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
