### PR TITLE
Add support for patching env variable for Path on Mac

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "feature/*" ]
 
 jobs:
   build:

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProvider.java
@@ -11,7 +11,6 @@ import java.io.OutputStream;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProvider.java
@@ -89,7 +89,7 @@ public class QLspConnectionProvider extends AbstractLspConnectionProvider {
             if (shell == null || shell.isEmpty()) {
                 shell = "/bin/zsh"; // fallback
             }
-            var pb = new ProcessBuilder(shell, "-l", "-c", "-i",  "echo $PATH");
+            var pb = new ProcessBuilder(shell, "-l", "-c", "printenv PATH");
             pb.redirectErrorStream(true);
             var process = pb.start();
             String shellPath = null;

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProvider.java
@@ -85,7 +85,6 @@ public class QLspConnectionProvider extends AbstractLspConnectionProvider {
             if (!PluginUtils.getPlatform().equals(PluginPlatform.MAC)) {
                 return false;
             }
-
             return hasInvalidPath(System.getenv("PATH"));
         } catch (Exception e) {
             Activator.getLogger().error("Error occurred when determining if patch variables are needed", e);

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProviderTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProviderTest.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.lsp4e.server.ProcessStreamConnectionProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.MockedStatic;
@@ -51,8 +53,7 @@ public final class QLspConnectionProviderTest {
     @RegisterExtension
     private static ProxyUtilsStaticMockExtension proxyUtilsStaticMockExtension = new ProxyUtilsStaticMockExtension();
 
-    @RegisterExtension
-    private static MockedStatic<PluginUtils> pluginUtilsMock = Mockito.mockStatic(PluginUtils.class);
+    private MockedStatic<PluginUtils> pluginUtilsMock;
 
     private static final class TestProcessConnectionProvider extends ProcessStreamConnectionProvider {
 
@@ -72,6 +73,19 @@ public final class QLspConnectionProviderTest {
             super.addEnvironmentVariables(env);
         }
 
+    }
+
+    @BeforeEach
+    void setupMocks() {
+        pluginUtilsMock = Mockito.mockStatic(PluginUtils.class);
+        pluginUtilsMock.when(PluginUtils::getPlatform).thenReturn(PluginPlatform.LINUX);
+    }
+
+    @AfterEach
+    void tearDownMocks() {
+        if (pluginUtilsMock != null) {
+            pluginUtilsMock.close();
+        }
     }
 
     @Test
@@ -107,7 +121,6 @@ public final class QLspConnectionProviderTest {
 
         MockedStatic<ProxyUtil> proxyUtilStaticMock = proxyUtilsStaticMockExtension.getStaticMock();
         proxyUtilStaticMock.when(ProxyUtil::getHttpsProxyUrl).thenReturn("");
-        pluginUtilsMock.when(PluginUtils::getPlatform).thenReturn(PluginPlatform.LINUX);
 
         Map<String, String> env = new HashMap<>();
 
@@ -128,7 +141,6 @@ public final class QLspConnectionProviderTest {
 
         MockedStatic<ProxyUtil> proxyUtilStaticMock = proxyUtilsStaticMockExtension.getStaticMock();
         proxyUtilStaticMock.when(ProxyUtil::getHttpsProxyUrl).thenReturn("http://proxy:8080");
-        pluginUtilsMock.when(PluginUtils::getPlatform).thenReturn(PluginPlatform.LINUX);
 
         Map<String, String> env = new HashMap<>();
         env.put("HTTPS_PROXY", "http://proxy:8080");

--- a/plugin/tst/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProviderTest.java
+++ b/plugin/tst/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProviderTest.java
@@ -31,6 +31,8 @@ import software.aws.toolkits.eclipse.amazonq.extensions.implementation.ProxyUtil
 import software.aws.toolkits.eclipse.amazonq.lsp.encryption.LspEncryptionManager;
 import software.aws.toolkits.eclipse.amazonq.lsp.manager.LspInstallResult;
 import software.aws.toolkits.eclipse.amazonq.util.LoggingService;
+import software.aws.toolkits.eclipse.amazonq.util.PluginPlatform;
+import software.aws.toolkits.eclipse.amazonq.util.PluginUtils;
 import software.aws.toolkits.eclipse.amazonq.util.ProxyUtil;
 
 public final class QLspConnectionProviderTest {
@@ -49,6 +51,8 @@ public final class QLspConnectionProviderTest {
     @RegisterExtension
     private static ProxyUtilsStaticMockExtension proxyUtilsStaticMockExtension = new ProxyUtilsStaticMockExtension();
 
+    @RegisterExtension
+    private static MockedStatic<PluginUtils> pluginUtilsMock = Mockito.mockStatic(PluginUtils.class);
 
     private static final class TestProcessConnectionProvider extends ProcessStreamConnectionProvider {
 
@@ -103,6 +107,7 @@ public final class QLspConnectionProviderTest {
 
         MockedStatic<ProxyUtil> proxyUtilStaticMock = proxyUtilsStaticMockExtension.getStaticMock();
         proxyUtilStaticMock.when(ProxyUtil::getHttpsProxyUrl).thenReturn("");
+        pluginUtilsMock.when(PluginUtils::getPlatform).thenReturn(PluginPlatform.LINUX);
 
         Map<String, String> env = new HashMap<>();
 
@@ -123,6 +128,7 @@ public final class QLspConnectionProviderTest {
 
         MockedStatic<ProxyUtil> proxyUtilStaticMock = proxyUtilsStaticMockExtension.getStaticMock();
         proxyUtilStaticMock.when(ProxyUtil::getHttpsProxyUrl).thenReturn("http://proxy:8080");
+        pluginUtilsMock.when(PluginUtils::getPlatform).thenReturn(PluginPlatform.LINUX);
 
         Map<String, String> env = new HashMap<>();
         env.put("HTTPS_PROXY", "http://proxy:8080");


### PR DESCRIPTION
*Description of changes:*
When eclipse is launched through finder on MacOs, it is a known issue that it does not inherit env variables. This leads to MCP servers failing initialization since they rely on env variables like path for resolving relative paths.
This change launches a shell to get system env variables for Path and inject it into the node process in situations like this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
