### PR TITLE
Fix uri parsing for windows path for open diff

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspClientImpl.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspClientImpl.java
@@ -360,7 +360,7 @@ public class AmazonQLspClientImpl extends LanguageClientImpl implements AmazonQL
             try {
                 IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
                 IStorageEditorInput input = new InMemoryInput(
-                        new MemoryStorage(new Path(params.originalFileUri().getPath()).lastSegment(), ""));
+                        new MemoryStorage(new Path(params.originalFileUri()).lastSegment(), ""));
 
                 IEditorDescriptor defaultEditor = PlatformUI.getWorkbench().getEditorRegistry()
                         .getDefaultEditor(".java");

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/model/OpenFileDiffParams.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/model/OpenFileDiffParams.java
@@ -3,8 +3,6 @@
 
 package software.aws.toolkits.eclipse.amazonq.lsp.model;
 
-import java.net.URI;
-
-public record OpenFileDiffParams(URI originalFileUri, String originalFileContent, Boolean isDeleted,
+public record OpenFileDiffParams(String originalFileUri, String originalFileContent, Boolean isDeleted,
         String fileContent) {
 }


### PR DESCRIPTION

*Description of changes:*
OpenDiffFileParams deserialized into a URI format which didn't work correctly for windows system and threw a malformed error. This replaces the uri with a string for correct deserialization across platforms.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
