### PR TITLE
Avoid blocking on chat UI initialization due to LSP startup

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/assets/ChatWebViewAssetProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/assets/ChatWebViewAssetProvider.java
@@ -48,9 +48,11 @@ public final class ChatWebViewAssetProvider extends WebViewAssetProvider {
     @Override
     public void initialize() {
         if (content.isEmpty()) {
-            content = resolveContent();
-            Activator.getEventBroker().post(ChatWebViewAssetState.class,
-                    content.isPresent() ? ChatWebViewAssetState.RESOLVED : ChatWebViewAssetState.DEPENDENCY_MISSING);
+            ThreadingUtils.executeAsyncTask(() -> {
+                content = resolveContent();
+                Activator.getEventBroker().post(ChatWebViewAssetState.class,
+                        content.isPresent() ? ChatWebViewAssetState.RESOLVED : ChatWebViewAssetState.DEPENDENCY_MISSING);
+            });
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*
The plugin will get stuck on the Eclipse splash screen for potentially an extended period of time while the language server starts up. This occurs when the chat UI is being restored in the IDE since it needs the Mynah UI JS path - this was a blocking call previously.

*Description of changes:*
Makes the content resolution aspect of the chat UI render asynchronous. This will avoid blocking Eclipse and not show content in the Q panel until the LS has loaded and started.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
