### PR TITLE
feat: Add pinned context support for Amazon Q chat

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/models/ChatUIInboundCommandName.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/models/ChatUIInboundCommandName.java
@@ -15,7 +15,12 @@ public enum ChatUIInboundCommandName {
     GenericCommand("genericCommand"),
     ChatOptionsUpdate("aws/chat/chatOptionsUpdate"),
     ListMcpServers("aws/chat/listMcpServers"),
-    McpServerClick("aws/chat/mcpServerClick");
+    McpServerClick("aws/chat/mcpServerClick"),
+    ListRules("aws/chat/listRules"),
+    RuleClick("aws/chat/ruleClick"),
+    PinnedContextAdd("aws/chat/pinnedContextAdd"),
+    PinnedContextRemove("aws/chat/pinnedContextRemove"),
+    SendPinnedContext("aws/chat/sendPinnedContext");
 
     private final String value;
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspClient.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspClient.java
@@ -61,4 +61,10 @@ public interface AmazonQLspClient extends LanguageClient {
     @JsonNotification("aws/didCreateDirectory")
     void didCreateDirectory(Object params);
 
+    @JsonNotification("aws/chat/sendPinnedContext")
+    void sendPinnedContext(Object params);
+
+    @JsonNotification("aws/chat/activeEditorChanged")
+    void activeEditorChanged(Object params);
+
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServer.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServer.java
@@ -129,4 +129,22 @@ public interface AmazonQLspServer extends LanguageServer {
 
     @JsonRequest("aws/chat/mcpServerClick")
     CompletableFuture<Object> mcpServerClick(Object params);
+
+    @JsonRequest("aws/chat/listRules")
+    CompletableFuture<Object> listRules(Object params);
+
+    @JsonRequest("aws/chat/ruleClick")
+    CompletableFuture<Object> ruleClick(Object params);
+
+    @JsonNotification("aws/chat/pinnedContextAdd")
+    void pinnedContextAdd(Object params);
+
+    @JsonNotification("aws/chat/pinnedContextRemove")
+    void pinnedContextRemove(Object params);
+
+    @JsonNotification("aws/chat/sendPinnedContext")
+    void sendPinnedContext(Object params);
+    
+    @JsonNotification("aws/chat/activeEditorChanged")
+    void activeEditorChanged(Object params);
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServerBuilder.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServerBuilder.java
@@ -56,6 +56,7 @@ public class AmazonQLspServerBuilder extends Builder<AmazonQLspServer> {
         qOptions.put("developerProfiles", true);
         qOptions.put("customizationsWithMetadata", true);
         qOptions.put("mcp", true);
+        qOptions.put("pinnedContextEnabled", true);
         awsClientCapabilities.put("q", qOptions);
         Map<String, Object> window = new HashMap<>();
         window.put("showSaveFileDialog", true);

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/editor/ActiveEditorChangeListener.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/editor/ActiveEditorChangeListener.java
@@ -1,0 +1,210 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.lsp.editor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.jface.text.ITextSelection;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IFileEditorInput;
+import org.eclipse.ui.IPartListener2;
+import org.eclipse.ui.IWorkbenchPartReference;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.texteditor.ITextEditor;
+
+import software.aws.toolkits.eclipse.amazonq.lsp.AmazonQLspServer;
+import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
+
+/**
+ * Listens for active editor changes and notifies the language server
+ * with debouncing to avoid excessive notifications.
+ */
+public class ActiveEditorChangeListener implements IPartListener2 {
+    private static final long DEBOUNCE_DELAY_MS = 100L;
+
+    private final AmazonQLspServer languageServer;
+    private final ScheduledExecutorService executor;
+    private ScheduledFuture<?> debounceTask;
+
+    public ActiveEditorChangeListener(final AmazonQLspServer languageServer, final ScheduledExecutorService executor) {
+        this.languageServer = languageServer;
+        this.executor = executor;
+    }
+
+    @Override
+    public void partActivated(final IWorkbenchPartReference partRef) {
+        if (partRef.getPart(false) instanceof ITextEditor) {
+            handleEditorChange((ITextEditor) partRef.getPart(false));
+        }
+    }
+
+    @Override
+    public void partBroughtToTop(final IWorkbenchPartReference partRef) {
+        if (partRef.getPart(false) instanceof ITextEditor) {
+            handleEditorChange((ITextEditor) partRef.getPart(false));
+        }
+    }
+
+    @Override
+    public void partClosed(final IWorkbenchPartReference partRef) {
+        // When editor is closed, send notification with null values
+        handleEditorChange(null);
+    }
+
+    @Override
+    public void partDeactivated(final IWorkbenchPartReference partRef) {
+        // No action needed
+    }
+
+    @Override
+    public void partOpened(final IWorkbenchPartReference partRef) {
+        if (partRef.getPart(false) instanceof ITextEditor) {
+            handleEditorChange((ITextEditor) partRef.getPart(false));
+        }
+    }
+
+    @Override
+    public void partHidden(final IWorkbenchPartReference partRef) {
+        // No action needed
+    }
+
+    @Override
+    public void partVisible(final IWorkbenchPartReference partRef) {
+        if (partRef.getPart(false) instanceof ITextEditor) {
+            handleEditorChange((ITextEditor) partRef.getPart(false));
+        }
+    }
+
+    @Override
+    public void partInputChanged(final IWorkbenchPartReference partRef) {
+        if (partRef.getPart(false) instanceof ITextEditor) {
+            handleEditorChange((ITextEditor) partRef.getPart(false));
+        }
+    }
+
+    private void handleEditorChange(final ITextEditor editor) {
+        // Cancel any pending notification
+        if (debounceTask != null) {
+            debounceTask.cancel(false);
+        }
+
+        // Schedule a new notification after the debounce period
+        debounceTask = executor.schedule(() -> {
+            try {
+                Map<String, Object> params = createActiveEditorParams(editor);
+
+                // Send notification to language server
+                languageServer.activeEditorChanged(params);
+                Activator.getLogger().info("Active editor changed notification sent: "
+                    + (editor != null ? editor.getTitle() : "no editor"));
+
+            } catch (Exception e) {
+                Activator.getLogger().error("Failed to send active editor changed notification", e);
+            }
+        }, DEBOUNCE_DELAY_MS, TimeUnit.MILLISECONDS);
+    }
+
+    private Map<String, Object> createActiveEditorParams(final ITextEditor editor) {
+        Map<String, Object> params = new HashMap<>();
+
+        if (editor != null) {
+            IEditorInput editorInput = editor.getEditorInput();
+
+            if (editorInput instanceof IFileEditorInput) {
+                IFileEditorInput fileInput = (IFileEditorInput) editorInput;
+                IFile file = fileInput.getFile();
+
+                // Create textDocument with workspace-relative path if in workspace, absolute otherwise
+                Map<String, String> textDocument = new HashMap<>();
+                if (file.getWorkspace().getRoot().exists(file.getFullPath())) {
+                    // workspace-relative path
+                    textDocument.put("uri", file.getFullPath().toString());
+                } else {
+                    // absolute path
+                    textDocument.put("uri", file.getLocation().toString());
+                }
+                params.put("textDocument", textDocument);
+
+                // Add cursor state if available
+                try {
+                    ITextSelection selection = (ITextSelection) editor.getSelectionProvider().getSelection();
+                    if (selection != null) {
+                        Map<String, Object> cursorState = new HashMap<>();
+                        Map<String, Integer> range = new HashMap<>();
+                        range.put("start", selection.getOffset());
+                        range.put("end", selection.getOffset() + selection.getLength());
+                        cursorState.put("range", range);
+                        params.put("cursorState", cursorState);
+                    }
+                } catch (Exception e) {
+                    // Cursor state is optional, continue without it
+                    Activator.getLogger().info("Could not get cursor state: " + e.getMessage());
+                }
+            }
+        } else {
+            // Editor is null (closed), send null values
+            params.put("textDocument", null);
+            params.put("cursorState", null);
+        }
+
+        return params;
+    }
+
+    /**
+     * Register the listener with the workbench.
+     */
+    public static ActiveEditorChangeListener register(final AmazonQLspServer languageServer, final ScheduledExecutorService executor) {
+        ActiveEditorChangeListener listener = new ActiveEditorChangeListener(languageServer, executor);
+
+        // Register with all workbench windows
+        PlatformUI.getWorkbench().addWindowListener(new org.eclipse.ui.IWindowListener() {
+            @Override
+            public void windowActivated(final org.eclipse.ui.IWorkbenchWindow window) {
+                window.getPartService().addPartListener(listener);
+            }
+
+            @Override
+            public void windowDeactivated(final org.eclipse.ui.IWorkbenchWindow window) {
+                // Keep listener active
+            }
+
+            @Override
+            public void windowClosed(final org.eclipse.ui.IWorkbenchWindow window) {
+                window.getPartService().removePartListener(listener);
+            }
+
+            @Override
+            public void windowOpened(final org.eclipse.ui.IWorkbenchWindow window) {
+                window.getPartService().addPartListener(listener);
+            }
+        });
+
+        // Register with current active window if available
+        if (PlatformUI.getWorkbench().getActiveWorkbenchWindow() != null) {
+            PlatformUI.getWorkbench().getActiveWorkbenchWindow().getPartService().addPartListener(listener);
+        }
+
+        return listener;
+    }
+
+    /**
+     * Unregister the listener.
+     */
+    public void dispose() {
+        if (debounceTask != null) {
+            debounceTask.cancel(true);
+        }
+
+        // Remove from all workbench windows
+        for (org.eclipse.ui.IWorkbenchWindow window : PlatformUI.getWorkbench().getWorkbenchWindows()) {
+            window.getPartService().removePartListener(this);
+        }
+    }
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatViewActionHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatViewActionHandler.java
@@ -69,6 +69,11 @@ public class AmazonQChatViewActionHandler implements ViewActionHandler {
             case TAB_BAR_ACTION:
             case LIST_MCP_SERVERS:
             case MCP_SERVER_CLICK:
+            case LIST_RULES:
+            case RULE_CLICK:
+            case PINNED_CONTEXT_ADD:
+            case PINNED_CONTEXT_REMOVE:
+            case SEND_PINNED_CONTEXT:
                 chatCommunicationManager.sendMessageToChatServer(command, message);
                 break;
             case CHAT_INFO_LINK_CLICK:

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/Command.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/Command.java
@@ -40,6 +40,11 @@ public enum Command {
     OPEN_SETTINGS("openSettings"),
     LIST_MCP_SERVERS("aws/chat/listMcpServers"),
     MCP_SERVER_CLICK("aws/chat/mcpServerClick"),
+    LIST_RULES("aws/chat/listRules"),
+    RULE_CLICK("aws/chat/ruleClick"),
+    PINNED_CONTEXT_ADD("aws/chat/pinnedContextAdd"),
+    PINNED_CONTEXT_REMOVE("aws/chat/pinnedContextRemove"),
+    SEND_PINNED_CONTEXT("aws/chat/sendPinnedContext"),
 
     // Auth
     LOGIN_BUILDER_ID("loginBuilderId"),


### PR DESCRIPTION
### Summary
This PR implements pinned context functionality for Amazon Q Eclipse plugin, allowing users to pin files
to their chat conversations for persistent context. This feature improves the relevance of Amazon Q
responses by maintaining important context throughout the conversation.

### What does this PR do?
  - Adds the ability to pin/unpin files in Amazon Q chat conversations
  - Implements automatic active editor tracking with 100ms debouncing
  - Enables the `@Pin Context` feature visible in the chat UI
  - Provides LSP server integration for pinned context operations

### Screenshot

<img width="676" alt="Screenshot 2025-06-26 at 1 05 26 PM" src="https://github.com/user-attachments/assets/f0fc59bd-e15f-41b6-9e66-132b7329f861" />

### Key Changes

#### 1. Command Infrastructure
- Added new commands to `ChatUIInboundCommandName.java`:
   - `PinnedContextAdd` - Pin a file to the conversation
   - `PinnedContextRemove` - Unpin a file
   - `SendPinnedContext` - Send pinned context with chat messages
   - `ListRules` - List available context rules
   - `RuleClick` - Handle rule selection

- Extended `Command.java` enum with corresponding command values

#### 2. LSP Server Integration
  - Extended `AmazonQLspServer.java` interface
  - Implemented methods in `AmazonQLspClient.java` and `AmazonQLspClientImpl.java`

#### 3. Active Editor Tracking
- Created `ActiveEditorChangeListener.java`:
   - Implements `IPartListener2` for editor lifecycle events
   - 100ms debouncing to prevent excessive notifications
   - Automatically tracks when users switch between files
   - Registers with all workbench windows

#### 4. Client Capabilities
  - Added `pinnedContextEnabled: true` flag in `AmazonQLspServerBuilder.java`
  - Enables pinned context features in the LSP server

#### 5. Command Routing
  - Updated `AmazonQChatViewActionHandler.java` to route pinned context commands
  - Added cases in `ChatCommunicationManager.java` for processing commands

### Testing Performed
  - ✅ Pin button appears in chat UI as "@Pin Context"
  - ✅ Files can be pinned to conversations
  - ✅ Pinned context commands are properly routed to LSP server
  - ✅ Active editor changes are tracked with debouncing
  - ✅ No compilation errors or checkstyle violations
  - ✅ Feature builds successfully with `mvn clean install`

### Known Issues
  - (WIP)

### How to Test
  1. Build and run the Eclipse plugin
  2. Open Amazon Q chat view
  3. Look for the "@Pin Context" option in the chat interface
  4. Pin a file and send a chat message
  5. Switch between editors and observe active editor tracking
  6. Check logs for pinned context operations

### Checklist
  - [x] Code compiles without errors
  - [x] Feature tested locally


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
