### PR TITLE
 feat: Add pinned context support for Amazon Q chat

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
@@ -261,7 +261,7 @@ public final class ChatCommunicationManager implements EventObserver<ChatUIInbou
                     case LIST_RULES:
                         try {
                             Object listRulesResponse = amazonQLspServer.listRules(message.getData()).get();
-                            var listRulesCommand = ChatUIInboundCommand.createCommand("aws/chat/listRules",
+                            var listRulesCommand = ChatUIInboundCommand.createCommand(ChatUIInboundCommandName.ListRules.getValue(),
                                     listRulesResponse);
                             Activator.getEventBroker().post(ChatUIInboundCommand.class, listRulesCommand);
                         } catch (Exception e) {
@@ -271,7 +271,7 @@ public final class ChatCommunicationManager implements EventObserver<ChatUIInbou
                     case RULE_CLICK:
                         try {
                             Object ruleClickResponse = amazonQLspServer.ruleClick(message.getData()).get();
-                            var ruleClickCommand = ChatUIInboundCommand.createCommand("aws/chat/ruleClick",
+                            var ruleClickCommand = ChatUIInboundCommand.createCommand(ChatUIInboundCommandName.RuleClick.getValue(),
                                     ruleClickResponse);
                             Activator.getEventBroker().post(ChatUIInboundCommand.class, ruleClickCommand);
                         } catch (Exception e) {
@@ -279,18 +279,10 @@ public final class ChatCommunicationManager implements EventObserver<ChatUIInbou
                         }
                         break;
                     case PINNED_CONTEXT_ADD:
-                        try {
-                            amazonQLspServer.pinnedContextAdd(message.getData());
-                        } catch (Exception e) {
-                            Activator.getLogger().error("Pinned Context: Error processing add command: " + e);
-                        }
+                        amazonQLspServer.pinnedContextAdd(message.getData());
                         break;
                     case PINNED_CONTEXT_REMOVE:
-                        try {
-                            amazonQLspServer.pinnedContextRemove(message.getData());
-                        } catch (Exception e) {
-                            Activator.getLogger().error("Pinned Context: Error processing remove command: " + e);
-                        }
+                        amazonQLspServer.pinnedContextRemove(message.getData());
                         break;
                     default:
                         throw new AmazonQPluginException("Unexpected command received from Chat UI: " + command.toString());

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
@@ -280,7 +280,6 @@ public final class ChatCommunicationManager implements EventObserver<ChatUIInbou
                         break;
                     case PINNED_CONTEXT_ADD:
                         try {
-                            Activator.getLogger().info("Pinned Context: Processing add command with data: " + message.getData());
                             amazonQLspServer.pinnedContextAdd(message.getData());
                         } catch (Exception e) {
                             Activator.getLogger().error("Pinned Context: Error processing add command: " + e);
@@ -288,7 +287,6 @@ public final class ChatCommunicationManager implements EventObserver<ChatUIInbou
                         break;
                     case PINNED_CONTEXT_REMOVE:
                         try {
-                            Activator.getLogger().info("Pinned Context: Processing remove command");
                             amazonQLspServer.pinnedContextRemove(message.getData());
                         } catch (Exception e) {
                             Activator.getLogger().error("Pinned Context: Error processing remove command: " + e);
@@ -305,7 +303,6 @@ public final class ChatCommunicationManager implements EventObserver<ChatUIInbou
             return null;
         });
     }
-
 
     public void sendInlineChatMessageToChatServer(final ChatMessage chatMessage) {
         Activator.getLspProvider().getAmazonQServer().thenAcceptAsync(amazonQLspServer -> {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
@@ -258,6 +258,42 @@ public final class ChatCommunicationManager implements EventObserver<ChatUIInbou
                             Activator.getLogger().error("Error processing mcpServerClick: " + e);
                         }
                         break;
+                    case LIST_RULES:
+                        try {
+                            Object listRulesResponse = amazonQLspServer.listRules(message.getData()).get();
+                            var listRulesCommand = ChatUIInboundCommand.createCommand("aws/chat/listRules",
+                                    listRulesResponse);
+                            Activator.getEventBroker().post(ChatUIInboundCommand.class, listRulesCommand);
+                        } catch (Exception e) {
+                            Activator.getLogger().error("Error processing listRules: " + e);
+                        }
+                        break;
+                    case RULE_CLICK:
+                        try {
+                            Object ruleClickResponse = amazonQLspServer.ruleClick(message.getData()).get();
+                            var ruleClickCommand = ChatUIInboundCommand.createCommand("aws/chat/ruleClick",
+                                    ruleClickResponse);
+                            Activator.getEventBroker().post(ChatUIInboundCommand.class, ruleClickCommand);
+                        } catch (Exception e) {
+                            Activator.getLogger().error("Error processing ruleClick: " + e);
+                        }
+                        break;
+                    case PINNED_CONTEXT_ADD:
+                        try {
+                            Activator.getLogger().info("Pinned Context: Processing add command with data: " + message.getData());
+                            amazonQLspServer.pinnedContextAdd(message.getData());
+                        } catch (Exception e) {
+                            Activator.getLogger().error("Pinned Context: Error processing add command: " + e);
+                        }
+                        break;
+                    case PINNED_CONTEXT_REMOVE:
+                        try {
+                            Activator.getLogger().info("Pinned Context: Processing remove command");
+                            amazonQLspServer.pinnedContextRemove(message.getData());
+                        } catch (Exception e) {
+                            Activator.getLogger().error("Pinned Context: Error processing remove command: " + e);
+                        }
+                        break;
                     default:
                         throw new AmazonQPluginException("Unexpected command received from Chat UI: " + command.toString());
                 }
@@ -269,6 +305,7 @@ public final class ChatCommunicationManager implements EventObserver<ChatUIInbou
             return null;
         });
     }
+
 
     public void sendInlineChatMessageToChatServer(final ChatMessage chatMessage) {
         Activator.getLspProvider().getAmazonQServer().thenAcceptAsync(amazonQLspServer -> {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/models/ChatUIInboundCommandName.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/models/ChatUIInboundCommandName.java
@@ -15,7 +15,12 @@ public enum ChatUIInboundCommandName {
     GenericCommand("genericCommand"),
     ChatOptionsUpdate("aws/chat/chatOptionsUpdate"),
     ListMcpServers("aws/chat/listMcpServers"),
-    McpServerClick("aws/chat/mcpServerClick");
+    McpServerClick("aws/chat/mcpServerClick"),
+    ListRules("aws/chat/listRules"),
+    RuleClick("aws/chat/ruleClick"),
+    PinnedContextAdd("aws/chat/pinnedContextAdd"),
+    PinnedContextRemove("aws/chat/pinnedContextRemove"),
+    SendPinnedContext("aws/chat/sendPinnedContext");
 
     private final String value;
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/models/ChatUIInboundCommandName.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/models/ChatUIInboundCommandName.java
@@ -18,8 +18,6 @@ public enum ChatUIInboundCommandName {
     McpServerClick("aws/chat/mcpServerClick"),
     ListRules("aws/chat/listRules"),
     RuleClick("aws/chat/ruleClick"),
-    PinnedContextAdd("aws/chat/pinnedContextAdd"),
-    PinnedContextRemove("aws/chat/pinnedContextRemove"),
     SendPinnedContext("aws/chat/sendPinnedContext");
 
     private final String value;

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspClient.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspClient.java
@@ -61,4 +61,6 @@ public interface AmazonQLspClient extends LanguageClient {
     @JsonNotification("aws/didCreateDirectory")
     void didCreateDirectory(Object params);
 
+    @JsonNotification("aws/chat/sendPinnedContext")
+    void sendPinnedContext(Object params);
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspClientImpl.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspClientImpl.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -26,6 +27,7 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
+
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.action.IAction;
@@ -639,11 +641,10 @@ public class AmazonQLspClientImpl extends LanguageClientImpl implements AmazonQL
             }
 
             if (StringUtils.startsWithIgnoreCase(activeFilePath, workspaceRoot)) {
-                var relativePath = activeFilePath.substring(workspaceRoot.length());
-                if (relativePath.startsWith("\\") || relativePath.startsWith("/")) {
-                    relativePath = relativePath.substring(1);
-                }
-                return relativePath.replace('\\', '/');
+                var workspaceRootPath = Paths.get(workspaceRoot);
+                var activeFilePathObj = Paths.get(activeFilePath);
+                var relativePath = workspaceRootPath.relativize(activeFilePathObj).normalize();
+                return relativePath.toString().replace('\\', '/');
             }
 
             // Not in workspace, return absolute path

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspClientImpl.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspClientImpl.java
@@ -17,7 +17,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.resources.IWorkspace;
@@ -82,6 +84,7 @@ import software.aws.toolkits.eclipse.amazonq.lsp.model.OpenTabUiResponse;
 import software.aws.toolkits.eclipse.amazonq.lsp.model.SsoProfileData;
 import software.aws.toolkits.eclipse.amazonq.lsp.model.TelemetryEvent;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
+import software.aws.toolkits.eclipse.amazonq.util.QEclipseEditorUtils;
 import software.aws.toolkits.eclipse.amazonq.preferences.AmazonQPreferencePage;
 import software.aws.toolkits.eclipse.amazonq.telemetry.service.DefaultTelemetryService;
 import software.aws.toolkits.eclipse.amazonq.util.Constants;
@@ -223,15 +226,10 @@ public class AmazonQLspClientImpl extends LanguageClientImpl implements AmazonQL
             } else {
                 Display.getDefault().syncExec(() -> {
                     try {
-                        if (!isUriInWorkspace(uri)) {
-                            Activator.getLogger().error("Attempted to open file outside workspace: " + uri);
-                            success[0] = false;
-                        } else {
-                            IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
-                            IFileStore fileStore = EFS.getLocalFileSystem().getStore(new URI(uri));
-                            IDE.openEditorOnFileStore(page, fileStore);
-                            success[0] = true;
-                        }
+                        IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+                        IFileStore fileStore = EFS.getLocalFileSystem().getStore(new URI(uri));
+                        IDE.openEditorOnFileStore(page, fileStore);
+                        success[0] = true;
                     } catch (Exception e) {
                         Activator.getLogger().error("Error in UI thread while opening URI: " + uri, e);
                         success[0] = false;
@@ -573,6 +571,86 @@ public class AmazonQLspClientImpl extends LanguageClientImpl implements AmazonQL
         } catch (Exception e) {
             Activator.getLogger().error("Error validating URI location: " + uri, e);
             return false;
+        }
+    }
+
+    @Override
+    public final void sendPinnedContext(final Object params) {
+        Object updatedParams = params;
+        Optional<String> fileUri = getActiveFileUri();
+        if (fileUri.isPresent()) {
+            Map<String, Object> textDocument = Map.of("uri", fileUri.get());
+            if (params instanceof Map) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> paramsMap = new HashMap<>((Map<String, Object>) params);
+                paramsMap.put("textDocument", textDocument);
+                updatedParams = paramsMap;
+            } else {
+                updatedParams = Map.of("params", params, "textDocument", textDocument);
+            }
+        }
+
+        var sendPinnedContextCommand = new ChatUIInboundCommand("aws/chat/sendPinnedContext", null, updatedParams,
+                false, null);
+        Activator.getEventBroker().post(ChatUIInboundCommand.class, sendPinnedContextCommand);
+    }
+
+    private Optional<String> getActiveFileUri() {
+        AtomicReference<Optional<String>> fileUri = new AtomicReference<>();
+        Display.getDefault().syncExec(() -> {
+            try {
+                fileUri.set(getActiveEditorRelativePath());
+            } catch (Exception e) {
+                Activator.getLogger().error("Error getting active file URI", e);
+                fileUri.set(Optional.empty());
+            }
+        });
+        return fileUri.get();
+    }
+
+    private Optional<String> getActiveEditorRelativePath() {
+        var activeEditor = QEclipseEditorUtils.getActiveTextEditor();
+        if (activeEditor == null) {
+            return Optional.empty();
+        }
+        return QEclipseEditorUtils.getOpenFileUri(activeEditor.getEditorInput())
+                .map(this::getRelativePath);
+    }
+
+    private String getRelativePath(final String absoluteUri) {
+        try {
+            if (StringUtils.isBlank(absoluteUri)) {
+                return absoluteUri;
+            }
+
+            var uri = new URI(absoluteUri);
+            var activeFilePath = new File(uri).getCanonicalPath();
+
+            // Get workspace root path
+            var workspace = ResourcesPlugin.getWorkspace();
+            var workspacePath = workspace.getRoot().getLocation();
+            if (workspacePath == null) {
+                return activeFilePath;
+            }
+
+            var workspaceRoot = workspacePath.toFile().getCanonicalPath();
+            if (StringUtils.isBlank(workspaceRoot)) {
+                return activeFilePath;
+            }
+
+            if (StringUtils.startsWithIgnoreCase(activeFilePath, workspaceRoot)) {
+                var relativePath = activeFilePath.substring(workspaceRoot.length());
+                if (relativePath.startsWith("\\") || relativePath.startsWith("/")) {
+                    relativePath = relativePath.substring(1);
+                }
+                return relativePath.replace('\\', '/');
+            }
+
+            // Not in workspace, return absolute path
+            return activeFilePath;
+        } catch (Exception e) {
+            Activator.getLogger().error("Error occurred when attempting to determine relative path for: " + absoluteUri, e);
+            return absoluteUri;
         }
     }
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspClientImpl.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspClientImpl.java
@@ -66,6 +66,7 @@ import software.amazon.awssdk.services.toolkittelemetry.model.Sentiment;
 import software.aws.toolkits.eclipse.amazonq.chat.ChatAsyncResultManager;
 import software.aws.toolkits.eclipse.amazonq.chat.ChatCommunicationManager;
 import software.aws.toolkits.eclipse.amazonq.chat.models.ChatUIInboundCommand;
+import software.aws.toolkits.eclipse.amazonq.chat.models.ChatUIInboundCommandName;
 import software.aws.toolkits.eclipse.amazonq.chat.models.GetSerializedChatParams;
 import software.aws.toolkits.eclipse.amazonq.chat.models.GetSerializedChatResult;
 import software.aws.toolkits.eclipse.amazonq.chat.models.SerializedChatResult;
@@ -590,8 +591,7 @@ public class AmazonQLspClientImpl extends LanguageClientImpl implements AmazonQL
             }
         }
 
-        var sendPinnedContextCommand = new ChatUIInboundCommand("aws/chat/sendPinnedContext", null, updatedParams,
-                false, null);
+        var sendPinnedContextCommand = ChatUIInboundCommand.createCommand(ChatUIInboundCommandName.SendPinnedContext.getValue(), updatedParams);
         Activator.getEventBroker().post(ChatUIInboundCommand.class, sendPinnedContextCommand);
     }
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServer.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServer.java
@@ -129,4 +129,22 @@ public interface AmazonQLspServer extends LanguageServer {
 
     @JsonRequest("aws/chat/mcpServerClick")
     CompletableFuture<Object> mcpServerClick(Object params);
+
+    @JsonRequest("aws/chat/listRules")
+    CompletableFuture<Object> listRules(Object params);
+
+    @JsonRequest("aws/chat/ruleClick")
+    CompletableFuture<Object> ruleClick(Object params);
+
+    @JsonNotification("aws/chat/pinnedContextAdd")
+    void pinnedContextAdd(Object params);
+
+    @JsonNotification("aws/chat/pinnedContextRemove")
+    void pinnedContextRemove(Object params);
+
+    @JsonNotification("aws/chat/sendPinnedContext")
+    void sendPinnedContext(Object params);
+
+    @JsonNotification("aws/chat/activeEditorChanged")
+    void activeEditorChanged(Object params);
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServer.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServer.java
@@ -142,9 +142,6 @@ public interface AmazonQLspServer extends LanguageServer {
     @JsonNotification("aws/chat/pinnedContextRemove")
     void pinnedContextRemove(Object params);
 
-    @JsonNotification("aws/chat/sendPinnedContext")
-    void sendPinnedContext(Object params);
-
     @JsonNotification("aws/chat/activeEditorChanged")
     void activeEditorChanged(Object params);
 }

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServerBuilder.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServerBuilder.java
@@ -56,6 +56,7 @@ public class AmazonQLspServerBuilder extends Builder<AmazonQLspServer> {
         qOptions.put("developerProfiles", true);
         qOptions.put("customizationsWithMetadata", true);
         qOptions.put("mcp", true);
+        qOptions.put("pinnedContextEnabled", true);
         awsClientCapabilities.put("q", qOptions);
         Map<String, Object> window = new HashMap<>();
         window.put("showSaveFileDialog", true);

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/editor/ActiveEditorChangeListener.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/editor/ActiveEditorChangeListener.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ScheduledFuture;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IPartListener2;
 import org.eclipse.ui.IWorkbenchPartReference;
+import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.texteditor.ITextEditor;
 
@@ -22,7 +23,7 @@ public final class ActiveEditorChangeListener implements IPartListener2 {
     private static ActiveEditorChangeListener instance;
     private static final long DEBOUNCE_DELAY_MS = 100L;
     private ScheduledFuture<?> debounceTask;
-    private org.eclipse.ui.IWorkbenchWindow registeredWindow;
+    private IWorkbenchWindow registeredWindow;
 
     private ActiveEditorChangeListener() { }
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/editor/ActiveEditorChangeListener.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/editor/ActiveEditorChangeListener.java
@@ -1,0 +1,119 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.lsp.editor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ScheduledFuture;
+
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IPartListener2;
+import org.eclipse.ui.IWorkbenchPartReference;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.texteditor.ITextEditor;
+
+import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
+import software.aws.toolkits.eclipse.amazonq.util.QEclipseEditorUtils;
+import software.aws.toolkits.eclipse.amazonq.util.ThreadingUtils;
+
+public final class ActiveEditorChangeListener implements IPartListener2 {
+    private static ActiveEditorChangeListener instance;
+    private static final long DEBOUNCE_DELAY_MS = 100L;
+    private ScheduledFuture<?> debounceTask;
+    private org.eclipse.ui.IWorkbenchWindow registeredWindow;
+
+    private ActiveEditorChangeListener() { }
+
+    public static ActiveEditorChangeListener getInstance() {
+        if (instance == null) {
+            instance = new ActiveEditorChangeListener();
+        }
+        return instance;
+    }
+
+    public void initialize() {
+        Display.getDefault().asyncExec(() -> {
+            try {
+                registeredWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+                if (registeredWindow != null) {
+                    registeredWindow.getPartService().addPartListener(this);
+                }
+            } catch (Exception e) {
+                Activator.getLogger().error("Failed to initialize ActiveEditorChangeListener", e);
+            }
+        });
+    }
+
+    public void stop() {
+        if (debounceTask != null) {
+            debounceTask.cancel(true);
+        }
+        try {
+            if (registeredWindow != null) {
+                registeredWindow.getPartService().removePartListener(this);
+            }
+        } catch (Exception e) {
+            Activator.getLogger().error("Error stopping ActiveEditorChangeListener", e);
+        }
+    }
+
+    @Override
+    public void partActivated(final IWorkbenchPartReference partRef) {
+        if (partRef.getPart(false) instanceof ITextEditor) {
+            ITextEditor editor = (ITextEditor) partRef.getPart(false);
+            handleEditorChange(editor);
+        }
+    }
+
+    @Override
+    public void partClosed(final IWorkbenchPartReference partRef) {
+        if (partRef.getPart(false) instanceof ITextEditor) {
+            handleEditorChange(null);
+        }
+    }
+
+    private void handleEditorChange(final ITextEditor editor) {
+        // Cancel any pending notification
+        if (debounceTask != null) {
+            debounceTask.cancel(false);
+        }
+
+        // Schedule a new notification after the debounce period
+        debounceTask = (ScheduledFuture<?>) ThreadingUtils.scheduleAsyncTaskWithDelay(() -> {
+            Display.getDefault().syncExec(() -> {
+                try {
+                    Map<String, Object> params = createActiveEditorParams(editor);
+                    var lspServer = Activator.getLspProvider().getAmazonQServer().get();
+                    lspServer.activeEditorChanged(params);
+                } catch (Exception e) {
+                    Activator.getLogger().error("Failed to send active editor changed notification", e);
+                }
+            });
+        }, DEBOUNCE_DELAY_MS);
+    }
+
+    private Map<String, Object> createActiveEditorParams(final ITextEditor editor) {
+        Map<String, Object> params = new HashMap<>();
+        if (editor != null) {
+            Optional<String> fileUri = QEclipseEditorUtils.getOpenFileUri(editor.getEditorInput());
+            if (fileUri.isPresent()) {
+                Map<String, String> textDocument = new HashMap<>();
+                textDocument.put("uri", fileUri.get());
+                params.put("textDocument", textDocument);
+                QEclipseEditorUtils.getSelectionRange(editor).ifPresent(range -> {
+                    Map<String, Object> cursorState = new HashMap<>();
+                    cursorState.put("range", range);
+                    params.put("cursorState", cursorState);
+                });
+            }
+        } else {
+            // Editor is null (closed), send null values
+            params.put("textDocument", null);
+            params.put("cursorState", null);
+        }
+
+        return params;
+    }
+}

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/plugin/Activator.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/plugin/Activator.java
@@ -12,6 +12,7 @@ import software.aws.toolkits.eclipse.amazonq.configuration.PluginStore;
 import software.aws.toolkits.eclipse.amazonq.inlineChat.InlineChatEditorListener;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.DefaultLoginService;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.LoginService;
+import software.aws.toolkits.eclipse.amazonq.lsp.editor.ActiveEditorChangeListener;
 import software.aws.toolkits.eclipse.amazonq.providers.browser.AmazonQBrowserProvider;
 import software.aws.toolkits.eclipse.amazonq.providers.lsp.LspProvider;
 import software.aws.toolkits.eclipse.amazonq.providers.lsp.LspProviderImpl;
@@ -39,6 +40,7 @@ public class Activator extends AbstractUIPlugin {
     private static ViewRouter viewRouter = ViewRouter.builder().build();
     private final InlineChatEditorListener editorListener;
     private static WorkspaceChangeListener workspaceListener = WorkspaceChangeListener.getInstance();
+    private static ActiveEditorChangeListener activeEditorListener = ActiveEditorChangeListener.getInstance();
 
     public Activator() {
         super();
@@ -56,6 +58,7 @@ public class Activator extends AbstractUIPlugin {
         editorListener = InlineChatEditorListener.getInstance();
         editorListener.initialize();
         workspaceListener.start();
+        activeEditorListener.initialize();
     }
 
     @Override
@@ -64,6 +67,7 @@ public class Activator extends AbstractUIPlugin {
         super.stop(context);
         plugin = null;
         workspaceListener.stop();
+        activeEditorListener.stop();
         ThreadingUtils.shutdown();
     }
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/assets/ChatWebViewAssetProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/assets/ChatWebViewAssetProvider.java
@@ -140,7 +140,7 @@ public final class ChatWebViewAssetProvider extends WebViewAssetProvider {
         var disclaimerAcknowledged = Activator.getPluginStore().get(PluginStoreKeys.CHAT_DISCLAIMER_ACKNOWLEDGED);
         var pairProgrammingAcknowledged = Activator.getPluginStore().get(PluginStoreKeys.PAIR_PROGRAMMING_ACKNOWLEDGED);
         return String.format("""
-                <script type="text/javascript" src="%s" defer></script>
+                <script type="text/javascript" charset="UTF-8" src="%s" defer></script>
                 <script type="text/javascript">
                     %s
                     const init = () => {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QEclipseEditorUtils.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QEclipseEditorUtils.java
@@ -145,12 +145,10 @@ public final class QEclipseEditorUtils {
         }
     }
 
-    public static Optional<Range> getActiveSelectionRange() {
-        var editor = getActiveTextEditor();
+    public static Optional<Range> getSelectionRange(final ITextEditor editor) {
         if (editor == null) {
             return Optional.empty();
         }
-
         ISelection selection = getSelection(editor);
         var document = editor.getDocumentProvider().getDocument(editor.getEditorInput());
         if (selection instanceof ITextSelection textSelection) {
@@ -171,6 +169,11 @@ public final class QEclipseEditorUtils {
             }
         }
         return Optional.empty();
+    }
+
+    public static Optional<Range> getActiveSelectionRange() {
+        var editor = getActiveTextEditor();
+        return getSelectionRange(editor);
     }
 
     /*

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatViewActionHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatViewActionHandler.java
@@ -73,9 +73,6 @@ public class AmazonQChatViewActionHandler implements ViewActionHandler {
             case RULE_CLICK:
             case PINNED_CONTEXT_ADD:
             case PINNED_CONTEXT_REMOVE:
-            case SEND_PINNED_CONTEXT:
-                chatCommunicationManager.sendMessageToChatServer(command, message);
-                break;
             case CHAT_INFO_LINK_CLICK:
             case CHAT_LINK_CLICK:
             case CHAT_SOURCE_LINK_CLICK:

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatViewActionHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatViewActionHandler.java
@@ -69,6 +69,11 @@ public class AmazonQChatViewActionHandler implements ViewActionHandler {
             case TAB_BAR_ACTION:
             case LIST_MCP_SERVERS:
             case MCP_SERVER_CLICK:
+            case LIST_RULES:
+            case RULE_CLICK:
+            case PINNED_CONTEXT_ADD:
+            case PINNED_CONTEXT_REMOVE:
+            case SEND_PINNED_CONTEXT:
                 chatCommunicationManager.sendMessageToChatServer(command, message);
                 break;
             case CHAT_INFO_LINK_CLICK:

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatViewActionHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatViewActionHandler.java
@@ -73,6 +73,8 @@ public class AmazonQChatViewActionHandler implements ViewActionHandler {
             case RULE_CLICK:
             case PINNED_CONTEXT_ADD:
             case PINNED_CONTEXT_REMOVE:
+                chatCommunicationManager.sendMessageToChatServer(command, message);
+                break;
             case CHAT_INFO_LINK_CLICK:
             case CHAT_LINK_CLICK:
             case CHAT_SOURCE_LINK_CLICK:

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/Command.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/Command.java
@@ -44,8 +44,6 @@ public enum Command {
     RULE_CLICK("aws/chat/ruleClick"),
     PINNED_CONTEXT_ADD("aws/chat/pinnedContextAdd"),
     PINNED_CONTEXT_REMOVE("aws/chat/pinnedContextRemove"),
-    SEND_PINNED_CONTEXT("aws/chat/sendPinnedContext"),
-
     // Auth
     LOGIN_BUILDER_ID("loginBuilderId"),
     LOGIN_IDC("loginIdC"),

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/Command.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/Command.java
@@ -40,6 +40,11 @@ public enum Command {
     OPEN_SETTINGS("openSettings"),
     LIST_MCP_SERVERS("aws/chat/listMcpServers"),
     MCP_SERVER_CLICK("aws/chat/mcpServerClick"),
+    LIST_RULES("aws/chat/listRules"),
+    RULE_CLICK("aws/chat/ruleClick"),
+    PINNED_CONTEXT_ADD("aws/chat/pinnedContextAdd"),
+    PINNED_CONTEXT_REMOVE("aws/chat/pinnedContextRemove"),
+    SEND_PINNED_CONTEXT("aws/chat/sendPinnedContext"),
 
     // Auth
     LOGIN_BUILDER_ID("loginBuilderId"),


### PR DESCRIPTION
*Description of changes:*

This PR implements pinned context functionality for Amazon Q Eclipse plugin, allowing users to pin files
to their chat conversations for persistent context. This feature improves the relevance of Amazon Q
responses by maintaining important context throughout the conversation.

What does this PR do?
* Adds the ability to pin/unpin files in Amazon Q chat conversations
* Implements automatic active editor tracking with 100ms debouncing
* Enables the @Pin Context feature visible in the chat UI
* Provides LSP server integration for pinned context operations

This change also remove the `isUriInWorkspace` check for when  lsp sends `showDocument` notification to client. This check would gate the ability to open documents not present in the workspace which is required for paths associated with prompts/rules are stored on disk and require opening it in the IDE for editing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
