### PR TITLE
Fix issue where ideApi browser function is injected before browser is loaded

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/assets/ChatWebViewAssetProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/assets/ChatWebViewAssetProvider.java
@@ -57,6 +57,11 @@ public final class ChatWebViewAssetProvider extends WebViewAssetProvider {
     }
 
     @Override
+    public void setContent(final Browser browser) {
+        browser.setText(content.get());
+    }
+
+    @Override
     public void injectAssets(final Browser browser) {
         new BrowserFunction(browser, "ideCommand") {
             @Override
@@ -85,7 +90,6 @@ public final class ChatWebViewAssetProvider extends WebViewAssetProvider {
                 return null;
             }
         };
-        browser.setText(content.get());
     }
 
     private Optional<String> resolveContent() {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/assets/WebViewAssetProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/assets/WebViewAssetProvider.java
@@ -7,6 +7,7 @@ import org.eclipse.swt.browser.Browser;
 
 public abstract class WebViewAssetProvider {
 
+    public abstract void setContent(Browser browser);
     public abstract void injectAssets(Browser browser);
 
     public abstract void initialize();

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatWebview.java
@@ -54,13 +54,14 @@ public class AmazonQChatWebview extends AmazonQView implements ChatUiRequestList
                     Display.getDefault().asyncExec(() -> {
                         if (!browser.isDisposed()) {
                             browser.setVisible(true);
+                            webViewAssetProvider.injectAssets(browser);
                             chatCommunicationManager.activate();
                         }
                     });
                 }
             });
 
-            webViewAssetProvider.injectAssets(browser);
+            webViewAssetProvider.setContent(browser);
         }
 
         super.setupView(parent);

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/ToolkitLoginWebview.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/ToolkitLoginWebview.java
@@ -52,13 +52,14 @@ public final class ToolkitLoginWebview extends AmazonQView implements EventObser
                     Display.getDefault().asyncExec(() -> {
                         if (!browser.isDisposed()) {
                             browser.setVisible(true);
+                            webViewAssetProvider.injectAssets(browser);
                         }
                     });
                     Activator.getEventBroker().subscribe(UpdateRedirectUrlCommand.class, webviewReference);
                 }
             });
 
-            webViewAssetProvider.injectAssets(browser);
+            webViewAssetProvider.setContent(browser);
         }
 
         addFocusListener(parent, browser);


### PR DESCRIPTION
*Description of changes:*
This change fixes an issue where users get stuck on Amazon Q login screen and clicking continue does not result any action.
This was caused because the `window.ideApi` which connects the javascript to IDE was null. This was because of a similar issue highlighted here: https://github.com/eclipse-platform/eclipse.platform.swt/discussions/1274.
This issue follows the advice given here where the injection of the browserfunction now happens after the browser has fully loaded by calling in as part of the completed callback of the `browser.progresslistener`. This ensures the ideApi and telemetryApi callbacks are always there after load.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
