### PR TITLE
Pass modelSelction flag to server

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServerBuilder.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServerBuilder.java
@@ -56,6 +56,7 @@ public class AmazonQLspServerBuilder extends Builder<AmazonQLspServer> {
         qOptions.put("developerProfiles", true);
         qOptions.put("customizationsWithMetadata", true);
         qOptions.put("mcp", true);
+        qOptions.put("modelSelection", true);
         awsClientCapabilities.put("q", qOptions);
         Map<String, Object> window = new HashMap<>();
         window.put("showSaveFileDialog", true);


### PR DESCRIPTION
*Description of changes:*
Currently, we pass the modelSelection flag in createChat, but we need to pass it to server so that server knows if client has the ability or not. With this change we pass the modelSelection in awsCapabilities in lsp initilization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
