### PR TITLE
Pass IDE trusted system certs to Language server by default

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProvider.java
@@ -86,14 +86,13 @@ public class QLspConnectionProvider extends AbstractLspConnectionProvider {
             Activator.getLogger().info("Using user-defined CA cert: " + caCertPreference);
             return caCertPreference;
         }
-
         try {
             String pemContent = ProxyUtil.getCertificatesAsPem();
             if (StringUtils.isEmpty(pemContent)) {
                 return null;
             }
-            Activator.getLogger().info("Injecting IDE trusted certificates into NODE_EXTRA_CA_CERTS");
             var tempPath = Files.createTempFile("eclipse-q-extra-ca", ".pem");
+            Activator.getLogger().info("Injecting IDE trusted certificates from " + tempPath  + " into NODE_EXTRA_CA_CERTS");
             Files.write(tempPath, pemContent.getBytes());
             return tempPath.toString();
         } catch (Exception e) {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/connection/QLspConnectionProvider.java
@@ -7,6 +7,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -58,13 +59,14 @@ public class QLspConnectionProvider extends AbstractLspConnectionProvider {
     @Override
     protected final void addEnvironmentVariables(final Map<String, String> env) {
         String httpsProxyUrl = ProxyUtil.getHttpsProxyUrl();
-        String caCertPreference = Activator.getDefault().getPreferenceStore().getString(AmazonQPreferencePage.CA_CERT);
+        String caCertPath = getCaCert();
+
         if (!StringUtils.isEmpty(httpsProxyUrl)) {
             env.put("HTTPS_PROXY", httpsProxyUrl);
         }
-        if (!StringUtils.isEmpty(caCertPreference)) {
-            env.put("NODE_EXTRA_CA_CERTS", caCertPreference);
-            env.put("AWS_CA_BUNDLE", caCertPreference);
+        if (!StringUtils.isEmpty(caCertPath)) {
+            env.put("NODE_EXTRA_CA_CERTS", caCertPath);
+            env.put("AWS_CA_BUNDLE", caCertPath);
         }
         if (ArchitectureUtils.isWindowsArm()) {
             env.put("DISABLE_INDEXING_LIBRARY", "true");
@@ -75,6 +77,28 @@ public class QLspConnectionProvider extends AbstractLspConnectionProvider {
         if (needsPatchEnvVariables()) {
             Activator.getLogger().info("Adding required variables");
             addPatchVariables(env);
+        }
+    }
+
+    private String getCaCert() {
+        String caCertPreference = Activator.getDefault().getPreferenceStore().getString(AmazonQPreferencePage.CA_CERT);
+        if (!StringUtils.isEmpty(caCertPreference)) {
+            Activator.getLogger().info("Using user-defined CA cert: " + caCertPreference);
+            return caCertPreference;
+        }
+
+        try {
+            String pemContent = ProxyUtil.getCertificatesAsPem();
+            if (StringUtils.isEmpty(pemContent)) {
+                return null;
+            }
+            Activator.getLogger().info("Injecting IDE trusted certificates into NODE_EXTRA_CA_CERTS");
+            var tempPath = Files.createTempFile("eclipse-q-extra-ca", ".pem");
+            Files.write(tempPath, pemContent.getBytes());
+            return tempPath.toString();
+        } catch (Exception e) {
+            Activator.getLogger().warn("Could not create temp CA cert file", e);
+            return null;
         }
     }
 


### PR DESCRIPTION
*Description of changes:*
This change improves the proxy support story for the extension. With this, we honor customer CA cert if specified in the preferences UI. If it is not supplied, instead of leaving it blank, we now detect system certificates and send it over to the node based language server. This allows us to address some issues where users are on corporate proxies/firewalls that have a proxy url but not an explicitly defined cert and expects applications to honor system certs. 
We currently do the same system cert detection when downloading artifacts for lsp.


Follows a similar approach as JB: https://github.com/aws/aws-toolkit-jetbrains/pull/5553

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
