### PR TITLE
Support redirects with http client

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/HttpClientFactory.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/HttpClientFactory.java
@@ -27,7 +27,7 @@ public final class HttpClientFactory {
         if (instance == null) {
             synchronized (HttpClientFactory.class) {
                 if (instance == null) {
-                    var builder = HttpClient.newBuilder();
+                    var builder = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL);
                     var proxyUrl = ProxyUtil.getHttpsProxyUrl();
                     if (!StringUtils.isEmpty(proxyUrl)) {
                         InetSocketAddress proxyAddress = getProxyAddress(proxyUrl);


### PR DESCRIPTION
*Description of changes:*
Our http client does not support redirects. This blocks us from trying pre-release builds of the language server whose url often contains redirects. Adding this unblocks us from testing against those builds

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
