### PR TITLE
Add support for dynamically retrieving available models

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
@@ -278,6 +278,16 @@ public final class ChatCommunicationManager implements EventObserver<ChatUIInbou
                             Activator.getLogger().error("Error processing ruleClick: " + e);
                         }
                         break;
+                    case LIST_AVAILABLE_MODELS:
+                        try {
+                            Object listModelsResponse = amazonQLspServer.listAvailableModels(message.getData()).get();
+                            var listModelsCommand = ChatUIInboundCommand.createCommand(ChatUIInboundCommandName.ListAvailableModels.getValue(),
+                                    listModelsResponse);
+                            Activator.getEventBroker().post(ChatUIInboundCommand.class, listModelsCommand);
+                        } catch (Exception e) {
+                            Activator.getLogger().error("Error processing listAvailableModels: " + e);
+                        }
+                        break;
                     case PINNED_CONTEXT_ADD:
                         amazonQLspServer.pinnedContextAdd(message.getData());
                         break;

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/models/ChatUIInboundCommandName.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/models/ChatUIInboundCommandName.java
@@ -18,6 +18,7 @@ public enum ChatUIInboundCommandName {
     McpServerClick("aws/chat/mcpServerClick"),
     ListRules("aws/chat/listRules"),
     RuleClick("aws/chat/ruleClick"),
+    ListAvailableModels("aws/chat/listAvailableModels"),
     SendPinnedContext("aws/chat/sendPinnedContext");
 
     private final String value;

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServer.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspServer.java
@@ -136,6 +136,9 @@ public interface AmazonQLspServer extends LanguageServer {
     @JsonRequest("aws/chat/ruleClick")
     CompletableFuture<Object> ruleClick(Object params);
 
+    @JsonRequest("aws/chat/listAvailableModels")
+    CompletableFuture<Object> listAvailableModels(Object params);
+
     @JsonNotification("aws/chat/pinnedContextAdd")
     void pinnedContextAdd(Object params);
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatViewActionHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/AmazonQChatViewActionHandler.java
@@ -73,6 +73,7 @@ public class AmazonQChatViewActionHandler implements ViewActionHandler {
             case RULE_CLICK:
             case PINNED_CONTEXT_ADD:
             case PINNED_CONTEXT_REMOVE:
+            case LIST_AVAILABLE_MODELS:
                 chatCommunicationManager.sendMessageToChatServer(command, message);
                 break;
             case CHAT_INFO_LINK_CLICK:

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/Command.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/Command.java
@@ -44,6 +44,7 @@ public enum Command {
     RULE_CLICK("aws/chat/ruleClick"),
     PINNED_CONTEXT_ADD("aws/chat/pinnedContextAdd"),
     PINNED_CONTEXT_REMOVE("aws/chat/pinnedContextRemove"),
+    LIST_AVAILABLE_MODELS("aws/chat/listAvailableModels"),
     // Auth
     LOGIN_BUILDER_ID("loginBuilderId"),
     LOGIN_IDC("loginIdC"),


### PR DESCRIPTION
*Description of changes:*
Adds support to dynamically retrieve available models for a region(e.g., Claude 4, Claude 3.7, Claude 3.5) from the backend. Wires up the `aws/chat/listAvailableModels` protocol handler to support model selection in AmazonQ chat.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
