### PR TITLE
Create version update script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,26 @@ To send us a pull request, please:
 GitHub provides additional documentation on [forking a repository](https://help.github.com/articles/fork-a-repo/) and 
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
+## Updating Plugin Version
+
+To update the plugin version across all files:
+
+1. **Prerequisites**: Ensure you have Git Bash (Windows) or Terminal (Mac/Linux)
+2. **Run the version script**:
+   ```bash
+   ./update-version.sh [new-version]
+   ```
+   Example: `./update-version.sh 2.7.0`
+
+3. **What gets updated**:
+   - Root `pom.xml` version
+   - All child `pom.xml` parent versions
+   - `plugin/META-INF/MANIFEST.MF` Bundle-Version
+   - `feature/feature.xml` version
+   - `updatesite/category.xml` version references
+
+4. **Build with new version**: `mvn clean install` and `mvn clean package`
+
 ## Debugging/Running Locally
 To test your changes locally, you can run the plugin from your workspace by importing it into Eclipse.
 

--- a/update-version.sh
+++ b/update-version.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+    echo "Usage: ./update-version.sh [new-version]"
+    echo "Example: ./update-version.sh 2.4.0"
+    exit 1
+fi
+
+NEW_VERSION=$1
+
+# Validate version format (x.x.x)
+if ! [[ $NEW_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Version must be in format x.x.x (e.g., 2.4.0)"
+    echo "Provided: $NEW_VERSION"
+    exit 1
+fi
+
+echo "Updating to version $NEW_VERSION"
+
+# Update root pom.xml version
+sed -i "s/<version>.*-SNAPSHOT<\/version>/<version>$NEW_VERSION-SNAPSHOT<\/version>/" pom.xml
+
+# Update parent version in all child pom.xml files
+find . -name "pom.xml" -not -path "./pom.xml" -exec sed -i "s/<version>.*-SNAPSHOT<\/version>/<version>$NEW_VERSION-SNAPSHOT<\/version>/" {} \;
+
+# Update MANIFEST.MF
+sed -i "s/Bundle-Version: .*/Bundle-Version: $NEW_VERSION.qualifier/" plugin/META-INF/MANIFEST.MF
+
+# Update feature.xml
+sed -i "s/version=\".*\.qualifier\"/version=\"$NEW_VERSION.qualifier\"/g" feature/feature.xml
+
+# Update category.xml
+sed -i "s/version=\".*\.qualifier\"/version=\"$NEW_VERSION.qualifier\"/g" updatesite/category.xml
+sed -i "s/_.*\.qualifier\.jar/_$NEW_VERSION.qualifier.jar/g" updatesite/category.xml
+
+echo "Version updated to $NEW_VERSION"
+echo "Run 'mvn clean install' and 'mvn clean package' to build with new version"


### PR DESCRIPTION
*Description of changes:*
This change simplifies and improves the release process. Instead of manually doing an update across necessary files to update the plugin version(PR #502), this adds a script that would make the version updates necessary. A corresponding entry has been added in the Contributing guide.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
