### PR TITLE
Reduce Webkit rendering failures

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/chat/ChatCommunicationManager.java
@@ -72,8 +72,8 @@ public final class ChatCommunicationManager implements EventObserver<ChatUIInbou
     private final Map<String, Long> lastProcessedTimeMap = new ConcurrentHashMap<>();
 
     private static final int MINIMUM_PARTIAL_RESPONSE_LENGTH = 50;
-    private static final int MIN_DELAY_BETWEEN_PARTIALS = 500;
-    private static final int MAX_DELAY_BETWEEN_PARTIALS = 2500;
+    private static final int MIN_DELAY_BETWEEN_PARTIALS = 250;
+    private static final int MAX_DELAY_BETWEEN_PARTIALS = 1500;
     private static final int CHAR_COUNT_FOR_MAX_DELAY = 5000;
 
     private final ConcurrentHashMap<String, Object> partialResultLocks = new ConcurrentHashMap<>();
@@ -638,7 +638,10 @@ public final class ChatCommunicationManager implements EventObserver<ChatUIInbou
             // send partial response to UI if not cancelled in the interim
             if (Boolean.FALSE.equals(finalResultProcessed.get(token))) {
                 sendMessageToChatUI(new ChatUIInboundCommand(command, tabId, partialChatResult, true, null));
-                lastProcessedTimeMap.put(tabId, currentTime);
+                // only update timestamp for rate-limited messages (string body without additional messages)
+                if (!hasAdditionalMessages && body instanceof String) {
+                    lastProcessedTimeMap.put(tabId, currentTime);
+                }
             }
         }
     }


### PR DESCRIPTION
*Description of changes:*
This change is being made in correspondence to a mynah change https://github.com/aws/mynah-ui/pull/429
Certain icons were problematic when rendered by Webkit used by Eclipse on Mac which led to errors. Error was caused due to hitting transparency limits: `WebCore::GraphicsContextCG::endTransparencyLayer()`.
* To mitigate it in addition to upstream change, eclipse client will now inject a flag to the backing UI JS  to allow it to skip styling that handles transparency layers in particular within chat-item-cards. 
* In addition the progress.svg icon shown when a chat response is in progress is a complex animation that overloads Webkit. To mitigate it, a simple static spinner icon now overrides that problematic icon on the Eclipse side.
* The text rate limiting to avoid flooding the Webview has been reduced to prevent delays and the lastProcessingTime computation has been fixed. This was accidentally delaying (additionalMessage)button state changes as well that are not rate limited.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
