### PR TITLE
Expand Flare version constraint to include all 1.x.x versions

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/LspConstants.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/manager/LspConstants.java
@@ -32,7 +32,7 @@ public final class LspConstants {
 
     private static VersionRange createVersionRange() {
         try {
-            return VersionRange.createFromVersionSpec("[1.0.0, 1.50.0)");
+            return VersionRange.createFromVersionSpec("[1.0.0, 2.0.0)");
         } catch (InvalidVersionSpecificationException e) {
             throw new AmazonQPluginException("Failed to parse LSP supported version range", e);
         }


### PR DESCRIPTION
*Description of changes:*
When Eclipse first launched we had a very conservative approach to Flare version bumps. This involved a limited version range that was intended to be opened once a testing and release process was established. That has yet to occur and we are approaching the upper bound of this initial, restrictive range. This change increases the version range to contain all current and future `1.x.x` versions of Flare.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
