### PR TITLE
fix: make ADT custom editor detection more permissive

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/AutoTriggerPartListener.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/AutoTriggerPartListener.java
@@ -75,11 +75,10 @@ public final class AutoTriggerPartListener<T extends IDocumentListener & IAutoTr
         }
     }
 
-        private boolean isCustomizedEditorType(final IWorkbenchPart part) {
-            String className = part.getClass().getName();
-            return CUSTOM_EDITOR_PREFIXES.stream()
-                    .anyMatch(prefix -> className.startsWith(prefix));
-        }
+    private boolean isCustomizedEditorType(final IWorkbenchPart part) {
+        String className = part.getClass().getName();
+        return CUSTOM_EDITOR_PREFIXES.stream().anyMatch(prefix -> className.startsWith(prefix));
+    }
 
     private void attachDocumentListenerAndUpdateActiveDocument(final ITextEditor editor) {
         var document = editor.getDocumentProvider().getDocument(editor.getEditorInput());


### PR DESCRIPTION
*Description of changes:*
Current solution works great for `ProgramEditor` types but does not apply auto triggering behavior to other ADT editor types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
