### PR TITLE
fix: NPE when file is stored in semantic cache location where rawLocation returns null

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QEclipseEditorUtils.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/QEclipseEditorUtils.java
@@ -106,7 +106,7 @@ public final class QEclipseEditorUtils {
     public static Optional<String> getOpenFileUri() {
         try {
             return getOpenFilePath()
-            .map(filePath -> Paths.get(filePath).toUri().toString());
+                    .map(filePath -> Paths.get(filePath).toUri().toString());
         } catch (Exception e) {
             Activator.getLogger().error("Unexpected error when determining open file path", e);
             return Optional.empty();
@@ -146,10 +146,11 @@ public final class QEclipseEditorUtils {
                 // rather than the workspace location, so we need to reference the cached file path
                 return AbapUtil.getSemanticCachePath(file.getFullPath().toOSString());
             }
-            // Fallback to sematic cache location if rawLocation is null, one of the use case is also file when users connect to a remote SAP project
-            var rawLocation = file.getRawLocation();
-            var path = (rawLocation != null) ? rawLocation.toOSString() : AbapUtil.getSemanticCachePath(file.getFullPath().toOSString());
-            return path;
+            // Fallback to semantic cache location if rawLocation is null, one of the use
+            // cases is also file when users connect to a remote SAP project
+            return (file.getRawLocation() != null)
+                    ? file.getRawLocation().toOSString()
+                    : AbapUtil.getSemanticCachePath(file.getFullPath().toOSString());
         } else {
             throw new AmazonQPluginException("Unexpected editor input type: " + editorInput.getClass().getName());
         }
@@ -175,7 +176,8 @@ public final class QEclipseEditorUtils {
                 var end = new Position(endLine, endColumn);
                 return Optional.of(new Range(start, end));
             } catch (org.eclipse.jface.text.BadLocationException e) {
-                Activator.getLogger().error("Error occurred while attempting to determine selected text position in editor", e);
+                Activator.getLogger()
+                        .error("Error occurred while attempting to determine selected text position in editor", e);
             }
         }
         return Optional.empty();
@@ -187,7 +189,8 @@ public final class QEclipseEditorUtils {
     }
 
     /*
-     * Inserts the given text at cursor position and returns cursor position range of the text
+     * Inserts the given text at cursor position and returns cursor position range
+     * of the text
      */
     public static Optional<Range> insertAtCursor(final String text) {
         var editor = getActiveTextEditor();
@@ -257,8 +260,9 @@ public final class QEclipseEditorUtils {
         StringBuilder indentedText = new StringBuilder(lines.get(0));
         for (int i = 1; i < lines.size(); i++) {
             indentedText.append("\n")
-            .append(lines.get(i).isEmpty() ? "" : indentation) // Don't apply the gap to empty lines (eg: end of string may end in a newline)
-            .append(lines.get(i));
+                    .append(lines.get(i).isEmpty() ? "" : indentation) // Don't apply the gap to empty lines (eg: end of
+                                                                       // string may end in a newline)
+                    .append(lines.get(i));
         }
 
         return indentedText.toString();
@@ -271,7 +275,8 @@ public final class QEclipseEditorUtils {
             var content = document.get(lineOffset, offset - lineOffset);
 
             if (content.trim().isEmpty()) {
-                // if current line is blank or contains only whitespace, return line as indentation
+                // if current line is blank or contains only whitespace, return line as
+                // indentation
                 return content;
             }
             return content.substring(0, content.indexOf(content.trim()));
@@ -322,14 +327,18 @@ public final class QEclipseEditorUtils {
             public void notHandled(final String commandId, final NotHandledException exception) {
                 return;
             }
+
             @Override
-            public void postExecuteFailure(final String commandId, final org.eclipse.core.commands.ExecutionException exception) {
+            public void postExecuteFailure(final String commandId,
+                    final org.eclipse.core.commands.ExecutionException exception) {
                 return;
             }
+
             @Override
             public void postExecuteSuccess(final String commandId, final Object returnValue) {
                 return;
             }
+
             @Override
             public void preExecute(final String commandId, final ExecutionEvent event) {
                 callback.accept(commandId);
@@ -351,17 +360,18 @@ public final class QEclipseEditorUtils {
             return new GenericTypeheadProcessor();
         }
         switch (contentTypeName) {
-        // TODO: Add more supported file types here:
-        case "Java Source File":
-            IEclipsePreferences preferences = InstanceScope.INSTANCE.getNode("org.eclipse.jdt.ui");
-            boolean isBracesSetToAutoClose = preferences.getBoolean("closeBraces", true);
-            boolean isBracketsSetToAutoClose = preferences.getBoolean("closeBrackets", true);
-            boolean isStringSetToAutoClose = preferences.getBoolean("closeStrings", true);
-            return new JavaTypeaheadProcessor(editor, isBracesSetToAutoClose, isBracketsSetToAutoClose, isStringSetToAutoClose);
-        case "JavaScript Source File":
-            return new JavascriptTypeaheadProcessor();
-        default:
-            return new GenericTypeheadProcessor();
+            // TODO: Add more supported file types here:
+            case "Java Source File":
+                IEclipsePreferences preferences = InstanceScope.INSTANCE.getNode("org.eclipse.jdt.ui");
+                boolean isBracesSetToAutoClose = preferences.getBoolean("closeBraces", true);
+                boolean isBracketsSetToAutoClose = preferences.getBoolean("closeBrackets", true);
+                boolean isStringSetToAutoClose = preferences.getBoolean("closeStrings", true);
+                return new JavaTypeaheadProcessor(editor, isBracesSetToAutoClose, isBracketsSetToAutoClose,
+                        isStringSetToAutoClose);
+            case "JavaScript Source File":
+                return new JavascriptTypeaheadProcessor();
+            default:
+                return new GenericTypeheadProcessor();
         }
     }
 


### PR DESCRIPTION
…

*Issue #, if available:*


## After 

https://github.com/user-attachments/assets/3fb1f0f5-812b-4423-ac96-9d4dae0e170b





*Description of changes:*
```
ENTRY amazon-q-eclipse 4 0 2026-01-08 08:49:37.656
!MESSAGE Error processing inline completion request 68de3c55-64e5-4a70-aad1-68ed3fe1968d
!STACK 0
java.util.concurrent.ExecutionException: org.eclipse.lsp4j.jsonrpc.ResponseErrorException: Request aws/textDocument/inlineCompletionWithReferences failed with message: Cannot read properties of undefined (reading 'uri')
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073)
	at software.aws.toolkits.eclipse.amazonq.util.QInvocationSession.processRequest(QInvocationSession.java:220)
	at software.aws.toolkits.eclipse.amazonq.util.QInvocationSession.lambda$1(QInvocationSession.java:192)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.exec(CompletableFuture.java:1796)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
Caused by: org.eclipse.lsp4j.jsonrpc.ResponseErrorException: Request aws/textDocument/inlineCompletionWithReferences failed with message: Cannot read properties of undefined (reading 'uri')
	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.handleResponse(RemoteEndpoint.java:220)
	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.consume(RemoteEndpoint.java:204)
	at software.aws.toolkits.eclipse.amazonq.lsp.AmazonQLspServerBuilder.lambda$2(AmazonQLspServerBuilder.java:105)
	at org.eclipse.lsp4e.LanguageServerWrapper.lambda$3(LanguageServerWrapper.java:449)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.handleMessage(StreamMessageProducer.java:185)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.listen(StreamMessageProducer.java:97)
	at org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor.run(ConcurrentMessageProcessor.java:114)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)

!ENTRY amazon-q-eclipse 4 0 2026-01-08 08:49:40.237
!MESSAGE Unexpected error when determining open file path
!STACK 0
java.lang.NullPointerException: Cannot invoke "org.eclipse.core.runtime.IPath.toOSString()" because the return value of "org.eclipse.core.resources.IFile.getRawLocation()" is null
	at software.aws.toolkits.eclipse.amazonq.util.QEclipseEditorUtils.getOpenFilePath(QEclipseEditorUtils.java:149)
	at software.aws.toolkits.eclipse.amazonq.util.QEclipseEditorUtils.getOpenFileUri(QEclipseEditorUtils.java:121)
	at software.aws.toolkits.eclipse.amazonq.util.InlineCompletionUtils.cwParamsFromContext(InlineCompletionUtils.java:26)
	at software.aws.toolkits.eclipse.amazonq.util.QInvocationSession.invoke(QInvocationSession.java:162)
	at software.aws.toolkits.eclipse.amazonq.util.AutoTriggerDocumentListener.documentChanged(AutoTriggerDocumentListener.java:53)
	at org.eclipse.jface.text.AbstractDocument.doFireDocumentChanged2(AbstractDocument.java:762)
	at org.eclipse.jface.text.AbstractDocument.doFireDocumentChanged(AbstractDocument.java:730)
	at org.eclipse.jface.text.AbstractDocument.doFireDocumentChanged(AbstractDocument.java:714)
	at org.eclipse.jface.text.AbstractDocument.fireDocumentChanged(AbstractDocument.java:790)
	at org.eclipse.jface.text.AbstractDocument.replace(AbstractDocument.java:1132)
	at org.eclipse.core.internal.filebuffers.SynchronizableDocument.replace(SynchronizableDocument.java:271)
	at org.eclipse.jface.text.AbstractDocument.replace(AbstractDocument.java:1150)
	at org.eclipse.core.internal.filebuffers.SynchronizableDocument.replace(SynchronizableDocument.java:259)
	at org.eclipse.jface.text.DefaultDocumentAdapter.replaceTextRange(DefaultDocumentAdapter.java:225)
	at org.eclipse.swt.custom.StyledText.modifyContent(StyledText.java:7188)
	at org.eclipse.swt.custom.StyledText.sendKeyEvent(StyledText.java:8088)
	at org.eclipse.swt.custom.StyledText.doContent(StyledText.java:2069)
	at org.eclipse.swt.custom.StyledText.handleKey(StyledText.java:5771)
	at org.eclipse.swt.custom.StyledText.handleKeyDown(StyledText.java:5802)
	at org.eclipse.swt.custom.StyledText.lambda$32(StyledText.java:5481)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:91)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4364)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1217)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1241)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1226)
	at org.eclipse.swt.widgets.Widget.sendKeyEvent(Widget.java:1268)
	at org.eclipse.swt.widgets.Widget.sendKeyEvent(Widget.java:1264)
	at org.eclipse.swt.widgets.Widget.wmChar(Widget.java:1747)
	at org.eclipse.swt.widgets.Control.WM_CHAR(Control.java:4982)
	at org.eclipse.swt.widgets.Canvas.WM_CHAR(Canvas.java:341)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4859)
	at org.eclipse.swt.widgets.Canvas.windowProc(Canvas.java:336)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5132)
	at org.eclipse.swt.internal.win32.OS.DispatchMessage(Native Method)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3748)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1147)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1038)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:677)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:583)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:173)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:185)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:219)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:149)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:115)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:467)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:298)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:615)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:563)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1415)
```


<img width="1437" height="667" alt="image" src="https://github.com/user-attachments/assets/4f19beaf-6734-42de-acb5-55760b61c988" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
