### PR TITLE
fix: remove workspace index settings and LSP config

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspClientImpl.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/AmazonQLspClientImpl.java
@@ -134,14 +134,6 @@ public class AmazonQLspClientImpl extends LanguageClientImpl implements AmazonQL
                 qConfig.put(Constants.LSP_CUSTOMIZATION_CONFIGURATION_KEY, Objects.nonNull(storedCustomization) ? storedCustomization.getArn() : null);
                 qConfig.put(Constants.LSP_ENABLE_TELEMETRY_EVENTS_CONFIGURATION_KEY, false);
                 qConfig.put(Constants.LSP_OPT_OUT_TELEMETRY_CONFIGURATION_KEY, !DefaultTelemetryService.telemetryEnabled());
-                Map<String, Object> projectContextConfig = new HashMap<>();
-                boolean indexingSetting = Activator.getDefault().getPreferenceStore().getBoolean(AmazonQPreferencePage.WORKSPACE_INDEX);
-                boolean gpuIndexingSetting = Activator.getDefault().getPreferenceStore().getBoolean(AmazonQPreferencePage.USE_GPU_FOR_INDEXING);
-                int indexThreadsSetting = Activator.getDefault().getPreferenceStore().getInt(AmazonQPreferencePage.INDEX_WORKER_THREADS);
-                projectContextConfig.put(Constants.LSP_INDEXING_CONFIGURATION_KEY, indexingSetting);
-                projectContextConfig.put(Constants.LSP_GPU_INDEXING_CONFIGURATION_KEY, gpuIndexingSetting);
-                projectContextConfig.put(Constants.LSP_INDEX_THREADS_CONFIGURATION_KEY, indexThreadsSetting);
-                qConfig.put(Constants.LSP_PROJECT_CONTEXT_CONFIGURATION_KEY, projectContextConfig);
                 output.add(qConfig);
                 Activator.getLspProvider().activate(AmazonQLspServer.class);
             } else if (item.getSection().equals(Constants.LSP_CW_CONFIGURATION_KEY)) {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/preferences/AmazonQPreferenceInitializer.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/preferences/AmazonQPreferenceInitializer.java
@@ -18,9 +18,6 @@ public class AmazonQPreferenceInitializer extends AbstractPreferenceInitializer 
     public final void initializeDefaultPreferences() {
         IPreferenceStore store = Activator.getDefault().getPreferenceStore();
         store.setDefault(AmazonQPreferencePage.CODE_REFERENCE_OPT_IN, true);
-        store.setDefault(AmazonQPreferencePage.WORKSPACE_INDEX, false);
-        store.setDefault(AmazonQPreferencePage.USE_GPU_FOR_INDEXING, false);
-        store.setDefault(AmazonQPreferencePage.INDEX_WORKER_THREADS, 0);
         store.setDefault(AmazonQPreferencePage.TELEMETRY_OPT_IN, true);
         store.setDefault(AmazonQPreferencePage.Q_DATA_SHARING, true);
         store.setDefault(AmazonQPreferencePage.HTTPS_PROXY, "");

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/preferences/AmazonQPreferencePage.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/preferences/AmazonQPreferencePage.java
@@ -36,21 +36,10 @@ import software.aws.toolkits.eclipse.amazonq.util.ThreadingUtils;
 public class AmazonQPreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
     public static final String PREFERENCE_STORE_ID = "software.aws.toolkits.eclipse.preferences";
     public static final String CODE_REFERENCE_OPT_IN = "codeReferenceOptIn";
-    public static final String WORKSPACE_INDEX = "workspaceIndex";
-    public static final String USE_GPU_FOR_INDEXING = "useGpuForIndexing";
-    public static final String INDEX_WORKER_THREADS = "indexWorkerThreads";
     public static final String TELEMETRY_OPT_IN = "telemetryOptIn";
     public static final String Q_DATA_SHARING = "qDataSharing";
     public static final String HTTPS_PROXY = "httpsProxy";
     public static final String CA_CERT = "customCaCert";
-
-    private Boolean isWorkspaceIndexChecked;
-    private Boolean isGpuIndexingChecked;
-    private int indexWorkerThreads;
-
-    private Boolean changedWorkspaceIndexChecked;
-    private Boolean changedGpuIndexingChecked;
-    private int changedIndexWorkerThreads;
 
     private Boolean isTelemetryOptInChecked;
     private Boolean isQDataSharingOptInChecked;
@@ -67,12 +56,6 @@ public class AmazonQPreferencePage extends FieldEditorPreferencePage implements 
 
     @Override
     public final void init(final IWorkbench workbench) {
-        isWorkspaceIndexChecked = preferenceStore.getBoolean(WORKSPACE_INDEX);
-        changedWorkspaceIndexChecked = preferenceStore.getBoolean(WORKSPACE_INDEX);
-        isGpuIndexingChecked = preferenceStore.getBoolean(USE_GPU_FOR_INDEXING);
-        changedGpuIndexingChecked = preferenceStore.getBoolean(USE_GPU_FOR_INDEXING);
-        indexWorkerThreads = preferenceStore.getInt(INDEX_WORKER_THREADS);
-        changedIndexWorkerThreads = preferenceStore.getInt(INDEX_WORKER_THREADS);
         isTelemetryOptInChecked = preferenceStore.getBoolean(TELEMETRY_OPT_IN);
         changedTelemetryOptInChecked = preferenceStore.getBoolean(TELEMETRY_OPT_IN);
         isQDataSharingOptInChecked = preferenceStore.getBoolean(Q_DATA_SHARING);
@@ -87,10 +70,6 @@ public class AmazonQPreferencePage extends FieldEditorPreferencePage implements 
         createHorizontalSeparator();
         createHeading("Code Suggestions");
         createCodeReferenceOptInField();
-        createHeading("Workspace Indexing");
-        createWorkspaceIndexField();
-        createUseGpuForIndexingField();
-        createIndexWorkerThreadsField();
         createHeading("Data Sharing");
         createTelemetryOptInField();
         createHorizontalSeparator();
@@ -146,65 +125,6 @@ public class AmazonQPreferencePage extends FieldEditorPreferencePage implements 
                 PluginUtils.openWebpage(event.text);
             }
         });
-    }
-
-    private void createWorkspaceIndexField() {
-        Composite workspaceIndexComposite = new Composite(getFieldEditorParent(), SWT.NONE);
-        workspaceIndexComposite.setLayout(new GridLayout(2, false));
-        GridData workspaceIndexCompositeData = new GridData(SWT.FILL, SWT.CENTER, true, false);
-        workspaceIndexCompositeData.horizontalIndent = 20;
-        workspaceIndexComposite.setLayoutData(workspaceIndexCompositeData);
-
-        BooleanFieldEditor workspaceIndex = new BooleanFieldEditor(WORKSPACE_INDEX, "Workspace Index", workspaceIndexComposite) {
-            @Override
-            protected void valueChanged(final boolean oldValue, final boolean newValue) {
-                isWorkspaceIndexChecked = newValue;
-            }
-        };
-        addField(workspaceIndex);
-
-        createLabel("""
-                When you add @workspace to your question in Amazon Q chat, Amazon Q will index your workspace files locally\
-                \nto use as context for its response. Extra CPU usage is expected while indexing a workspace. This will not\
-                \nimpact Amazon Q features or your IDE, but you may manage CPU usage by setting the number of index threads.
-                """, 20, workspaceIndexComposite);
-    }
-
-    private void createUseGpuForIndexingField() {
-        Composite useGpuComposite = new Composite(getFieldEditorParent(), SWT.NONE);
-        useGpuComposite.setLayout(new GridLayout(2, false));
-        GridData useGpuCompositeData = new GridData(SWT.FILL, SWT.CENTER, true, false);
-        useGpuCompositeData.horizontalIndent = 20;
-        useGpuComposite.setLayoutData(useGpuCompositeData);
-
-        BooleanFieldEditor useGpuForIndexing = new BooleanFieldEditor(USE_GPU_FOR_INDEXING, "Use GPU for Indexing", useGpuComposite) {
-            @Override
-            protected void valueChanged(final boolean oldValue, final boolean newValue) {
-                isGpuIndexingChecked = newValue;
-            }
-        };
-        addField(useGpuForIndexing);
-
-        createLabel("""
-                Enable GPU to help index your local workspace files. Only applies to Linux and Windows.
-                """, 20, useGpuComposite);
-    }
-
-    private void createIndexWorkerThreadsField() {
-        Composite indexWorkerThreadsComposite = new Composite(getFieldEditorParent(), SWT.NONE);
-        indexWorkerThreadsComposite.setLayout(new GridLayout(2, false));
-        GridData indexWorkerThreadsCompositeData = new GridData(SWT.LEFT, SWT.CENTER, true, false);
-        indexWorkerThreadsCompositeData.horizontalIndent = 20;
-        indexWorkerThreadsComposite.setLayoutData(indexWorkerThreadsCompositeData);
-
-        StringFieldEditor indexWorkerThreads = new StringFieldEditor(INDEX_WORKER_THREADS, "Index Worker Threads", 10, indexWorkerThreadsComposite);
-        addField(indexWorkerThreads);
-
-        createLabel("""
-                Number of worker threads of Amazon Q local index process. '0' will use the system default worker threads for balance\
-                \nperformance. You may increase this number to more quickly index your workspace, but only up to your hardware's number\
-                \nof CPU cores. Please restart Eclipse after changing worker threads.
-                """, 20, getFieldEditorParent());
     }
 
     private void createTelemetryOptInField() {
@@ -351,23 +271,6 @@ public class AmazonQPreferencePage extends FieldEditorPreferencePage implements 
             isQDataSharingOptInChecked = changedDataSharingOptInChecked;
         }
 
-        if (changedWorkspaceIndexChecked != isWorkspaceIndexChecked) {
-            AwsTelemetryProvider.emitModifySettingEvent("amazonQ.workspaceIndexing",
-                    changedWorkspaceIndexChecked.toString());
-            isWorkspaceIndexChecked = changedWorkspaceIndexChecked;
-        }
-
-        if (changedGpuIndexingChecked != isGpuIndexingChecked) {
-            AwsTelemetryProvider.emitModifySettingEvent("amazonQ.gpuIndexing",
-                    changedGpuIndexingChecked.toString());
-            isGpuIndexingChecked = changedGpuIndexingChecked;
-        }
-
-        if (changedIndexWorkerThreads != indexWorkerThreads) {
-            AwsTelemetryProvider.emitModifySettingEvent("amazonQ.indexThreads",
-                    String.valueOf(changedIndexWorkerThreads));
-            indexWorkerThreads = changedIndexWorkerThreads;
-        }
         ThreadingUtils.executeAsyncTask(() -> CustomizationUtil.triggerChangeConfigurationNotification());
     }
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
@@ -11,10 +11,6 @@ public final class Constants {
 
     public static final String CUSTOMIZATION_STORAGE_INTERNAL_KEY = "aws.q.customization.eclipse";
     public static final String LSP_CUSTOMIZATION_CONFIGURATION_KEY = "customization";
-    public static final String LSP_PROJECT_CONTEXT_CONFIGURATION_KEY = "projectContext";
-    public static final String LSP_INDEXING_CONFIGURATION_KEY = "enableLocalIndexing";
-    public static final String LSP_GPU_INDEXING_CONFIGURATION_KEY = "enableGpuAcceleration";
-    public static final String LSP_INDEX_THREADS_CONFIGURATION_KEY = "indexWorkerThreads";
     public static final String LSP_ENABLE_TELEMETRY_EVENTS_CONFIGURATION_KEY = "enableTelemetryEventsToDestination";
     public static final String LSP_OPT_OUT_TELEMETRY_CONFIGURATION_KEY = "optOutTelemetry";
     public static final String LSP_Q_CONFIGURATION_KEY = "aws.q";


### PR DESCRIPTION
## Problem
The language-servers repo has removed `@workspace` (vector/semantic search) and no longer accepts these configuration fields: `enableLocalIndexing`, `enableGpuAcceleration`, `indexWorkerThreads`, `indexCacheDirPath`.

The IDE still exposes these settings to users and sends them to the language server, where they are ignored.

## Solution
- Remove workspace indexing preference page fields (workspace index, GPU, worker threads)
- Remove LSP config constants from `Constants.java`
- Remove `projectContext` config map from LSP client configuration
- Remove preference defaults from `AmazonQPreferenceInitializer.java`

Related: [aws/language-servers feature/removing-at-workspace](https://github.com/aws/language-servers/pull/2698)