### PR TITLE
feat: maintenance-mode UI for Amazon Q login

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/LoginViewActionHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/LoginViewActionHandler.java
@@ -102,21 +102,19 @@ public class LoginViewActionHandler implements ViewActionHandler {
             if (lastRegion == null || lastRegion.isEmpty()) {
                 lastRegion = "us-east-1";
             }
-            var js = String.format("""
-                    {
-                        stage: '%s',
-                        regions: %s,
-                        cancellable: false,
-                        idcInfo: {
-                            profileName: '',
-                            startUrl: '%s',
-                            region: '%s'
-                        },
-                        feature: 'q',
-                        existConnections: [],
-                        profiles: []
-                    }
-                        """, "START", regions, lastStartUrl, lastRegion).stripIndent();
+            var js = "{"
+                    + "stage: 'START',"
+                    + "regions: " + regions + ","
+                    + "cancellable: false,"
+                    + "idcInfo: {"
+                    + "  profileName: '',"
+                    + "  startUrl: '" + lastStartUrl + "',"
+                    + "  region: '" + lastRegion + "'"
+                    + "},"
+                    + "feature: 'q',"
+                    + "existConnections: [],"
+                    + "profiles: []"
+                    + "}";
             browser.execute("changeTheme(" + THEME_DETECTOR.isDarkTheme() + ");");
             browser.execute(String.format("ideClient.prepareUi(%s)", js));
             browser.execute("ideClient.updateAuthorization('')");

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/LoginViewActionHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/LoginViewActionHandler.java
@@ -13,6 +13,7 @@ import org.eclipse.swt.widgets.Display;
 
 import software.amazon.awssdk.regions.servicemetadata.OidcServiceMetadata;
 import software.amazon.awssdk.utils.StringUtils;
+import software.aws.toolkits.eclipse.amazonq.configuration.DefaultPluginStore;
 import software.aws.toolkits.eclipse.amazonq.configuration.customization.CustomizationUtil;
 import software.aws.toolkits.eclipse.amazonq.configuration.profiles.QDeveloperProfileUtil;
 import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.LoginIdcParams;
@@ -32,6 +33,8 @@ public class LoginViewActionHandler implements ViewActionHandler {
 
     private static final JsonHandler JSON_HANDLER = new JsonHandler();
     private static final ThemeDetector THEME_DETECTOR = new ThemeDetector();
+    private static final String LAST_IDC_START_URL_KEY = "lastIdcStartUrl";
+    private static final String LAST_IDC_REGION_KEY = "lastIdcRegion";
     private Future<?> loginTask;
     private boolean isLoginTaskRunning = false;
 
@@ -58,6 +61,9 @@ public class LoginViewActionHandler implements ViewActionHandler {
                         }
                         Activator.getLoginService().login(LoginType.IAM_IDENTITY_CENTER,
                                 new LoginParams().setLoginIdcParams(loginIdcParams)).get();
+                        // Persist last-used IdC info for next login
+                        DefaultPluginStore.getInstance().put(LAST_IDC_START_URL_KEY, url);
+                        DefaultPluginStore.getInstance().put(LAST_IDC_REGION_KEY, region);
                         if (QDeveloperProfileUtil.getInstance().isProfileSelectionRequired()) {
                             Map<String, Object> profilesData = new HashMap<>();
                             var profiles = QDeveloperProfileUtil.getInstance().getDeveloperProfiles();
@@ -88,6 +94,14 @@ public class LoginViewActionHandler implements ViewActionHandler {
                     + oidcMetadata.regions().stream().filter(region -> region.metadata().partition().id().equals("aws"))
                             .map(AwsRegion::from).map(AwsRegion::toString).collect(Collectors.joining(","))
                     + "]";
+            String lastStartUrl = DefaultPluginStore.getInstance().get(LAST_IDC_START_URL_KEY);
+            String lastRegion = DefaultPluginStore.getInstance().get(LAST_IDC_REGION_KEY);
+            if (lastStartUrl == null) {
+                lastStartUrl = "";
+            }
+            if (lastRegion == null || lastRegion.isEmpty()) {
+                lastRegion = "us-east-1";
+            }
             var js = String.format("""
                     {
                         stage: '%s',
@@ -95,14 +109,14 @@ public class LoginViewActionHandler implements ViewActionHandler {
                         cancellable: false,
                         idcInfo: {
                             profileName: '',
-                            startUrl: '',
-                            region: 'us-east-1'
+                            startUrl: '%s',
+                            region: '%s'
                         },
                         feature: 'q',
                         existConnections: [],
                         profiles: []
                     }
-                        """, "START", regions).stripIndent();
+                        """, "START", regions, lastStartUrl, lastRegion).stripIndent();
             browser.execute("changeTheme(" + THEME_DETECTOR.isDarkTheme() + ");");
             browser.execute(String.format("ideClient.prepareUi(%s)", js));
             browser.execute("ideClient.updateAuthorization('')");

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/LoginViewActionHandler.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/LoginViewActionHandler.java
@@ -21,6 +21,7 @@ import software.aws.toolkits.eclipse.amazonq.lsp.auth.model.LoginType;
 import software.aws.toolkits.eclipse.amazonq.plugin.Activator;
 import software.aws.toolkits.eclipse.amazonq.util.AwsRegion;
 import software.aws.toolkits.eclipse.amazonq.util.JsonHandler;
+import software.aws.toolkits.eclipse.amazonq.util.PluginUtils;
 import software.aws.toolkits.eclipse.amazonq.util.ThemeDetector;
 import software.aws.toolkits.eclipse.amazonq.util.ThreadingUtils;
 import software.aws.toolkits.eclipse.amazonq.views.model.Command;
@@ -111,6 +112,14 @@ public class LoginViewActionHandler implements ViewActionHandler {
             QDeveloperProfileUtil.getInstance().setDeveloperProfile(developerProfile, true).thenRun(() -> {
                 CustomizationUtil.validateCurrentCustomization();
             });
+            break;
+        case OPEN_URL:
+            if (params instanceof Map) {
+                var urlValue = ((Map<?, ?>) params).get("url");
+                if (urlValue instanceof String && !((String) urlValue).isEmpty()) {
+                    PluginUtils.handleExternalLinkClick((String) urlValue);
+                }
+            }
             break;
         default:
             Activator.getLogger()

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/Command.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/views/model/Command.java
@@ -51,7 +51,8 @@ public enum Command {
     LOGIN_IDC("loginIdC"),
     CANCEL_LOGIN("cancelLogin"),
     ON_LOAD("onLoad"),
-    ON_SELECT_PROFILE("onSelectProfile");
+    ON_SELECT_PROFILE("onSelectProfile"),
+    OPEN_URL("openUrl");
 
     private final String commandString;
 

--- a/plugin/webview/src/q-ui/assets/common.scss
+++ b/plugin/webview/src/q-ui/assets/common.scss
@@ -24,20 +24,20 @@ a {
 .font-amazon {
     font-family: "Amazon Ember", sans-serif;
     user-select: none;
-    font-size: 15px;
+    font-size: 13px;
 }
 
 .bottom-small-gap {
-    margin-bottom: 20px !important;
+    margin-bottom: 12px !important;
 }
 
 .login-flow-button {
     width: 100%;
-    height: 55px;
-    border-radius: 3px;
+    height: 30px;
+    border-radius: 4px;
     border-width: 0;
     font-weight: bold;
-    margin-bottom: 100px;
+    margin-bottom: 12px;
 }
 
 .continue-button {
@@ -54,7 +54,7 @@ a {
 .title {
     margin-bottom: 5px;
     margin-top: 5px;
-    font-size: 15px;
+    font-size: 14px;
     font-weight: bold;
 }
 
@@ -99,7 +99,7 @@ button:not([disabled]), .item-container {
 }
 
 .centered-with-max-width {
-    max-width: 300px;
+    max-width: 260px;
     margin: 0 auto;
 }
 

--- a/plugin/webview/src/q-ui/components/logo.vue
+++ b/plugin/webview/src/q-ui/components/logo.vue
@@ -36,8 +36,8 @@ export default defineComponent({
 
         <svg
             v-if="app === 'AMAZONQ' && !this.isConnected"
-            width="100"
-            height="100"
+            width="56"
+            height="56"
             viewBox="0 0 71 71"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
@@ -77,8 +77,8 @@ export default defineComponent({
         </svg>
         <svg
             v-if="app === 'TOOLKIT' && !this.isConnected"
-            width="100"
-            height="100"
+            width="72"
+            height="72"
             viewBox="0 0 54 54"
             fill="none"
             id="Layer_1"
@@ -107,9 +107,9 @@ export default defineComponent({
 .logoIconLeft {
     display: flex;
     flex-direction: row;
-    justify-content: left;
+    justify-content: center;
     align-items: flex-start;
-    padding-top: 75px;
+    padding-top: 65px;
     height: auto;
 }
 
@@ -118,7 +118,7 @@ export default defineComponent({
     flex-direction: row;
     justify-content: center;
     align-items: flex-start;
-    padding-top: 75px;
+    padding-top: 65px;
     height: auto;
 }
 

--- a/plugin/webview/src/q-ui/components/qOptions.vue
+++ b/plugin/webview/src/q-ui/components/qOptions.vue
@@ -3,23 +3,8 @@
 
 <template>
     <div @keydown.enter="handleContinueClick">
-        <div class="font-amazon" v-if="existConnections.length > 0">
-            <div class="title bottom-small-gap">Connect with an existing account:</div>
-            <div v-for="(connection, index) in this.existConnections" :key="index">
-                <SelectableItem
-                    @toggle="toggleItemSelection"
-                    :isSelected="selectedLoginOption === connection.id"
-                    :itemId="connection.id"
-                    :login-type="this.connectionType(connection)"
-                    :itemTitle="this.connectionDisplayedName(connection)"
-                    :itemText="this.connectionTypeDescription(connection)"
-                    class="bottom-small-gap"
-                ></SelectableItem>
-            </div>
-        </div>
-
-        <div class="title font-amazon welcome-header bottom-small-gap" v-if="existingLogin.id === -1">Welcome to Amazon Q</div>
-        <div class="maintenance-banner font-amazon bottom-small-gap" v-if="existingLogin.id === -1">
+        <div class="title font-amazon welcome-header bottom-small-gap">Welcome to Amazon Q</div>
+        <div class="maintenance-banner font-amazon bottom-small-gap">
             <span class="maintenance-banner__icon" aria-hidden="true">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path
@@ -39,7 +24,6 @@
             disabled
             aria-disabled="true"
             title="New account creation is no longer available"
-            v-if="existingLogin.id === -1"
         >
             <span>Create New Account</span>
             <svg class="create-account-button__lock" width="12" height="12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
@@ -49,7 +33,22 @@
                 />
             </svg>
         </button>
-        <div class="existing-users-divider font-amazon bottom-small-gap" v-if="existingLogin.id === -1"><span>existing users</span></div>
+        <div class="existing-users-divider font-amazon bottom-small-gap"><span>existing users</span></div>
+
+        <div class="font-amazon" v-if="existConnections.length > 0">
+            <div class="title bottom-small-gap">Connect with an account:</div>
+            <div v-for="(connection, index) in this.existConnections" :key="index">
+                <SelectableItem
+                    @toggle="toggleItemSelection"
+                    :isSelected="selectedLoginOption === connection.id"
+                    :itemId="connection.id"
+                    :login-type="this.connectionType(connection)"
+                    :itemTitle="this.connectionDisplayedName(connection)"
+                    :itemText="this.connectionTypeDescription(connection)"
+                    class="bottom-small-gap"
+                ></SelectableItem>
+            </div>
+        </div>
         <SelectableItem
             @toggle="toggleItemSelection"
             :isSelected="selectedLoginOption === LoginOption.BUILDER_ID"

--- a/plugin/webview/src/q-ui/components/qOptions.vue
+++ b/plugin/webview/src/q-ui/components/qOptions.vue
@@ -14,7 +14,7 @@
                 </svg>
             </span>
             <span class="maintenance-banner__text">
-                Amazon Q Developer is now in maintenance mode. New accounts are no longer available. Existing users can still sign in below.
+                Amazon Q Developer IDE plugins will reach end of support on April 30, 2027. New accounts are no longer available but existing users can still sign in below.
                 <a class="maintenance-banner__link" href="#" @click.prevent="handleLearnMoreClick">Learn more</a>
             </span>
         </div>

--- a/plugin/webview/src/q-ui/components/qOptions.vue
+++ b/plugin/webview/src/q-ui/components/qOptions.vue
@@ -18,23 +18,54 @@
             </div>
         </div>
 
-        <div class="title font-amazon bottom-small-gap" v-if="existingLogin.id === -1">Choose a sign-in option:</div>
+        <div class="title font-amazon welcome-header bottom-small-gap" v-if="existingLogin.id === -1">Welcome to Amazon Q</div>
+        <div class="maintenance-banner font-amazon bottom-small-gap" v-if="existingLogin.id === -1">
+            <span class="maintenance-banner__icon" aria-hidden="true">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                        d="M12 2L1 21h22L12 2zm0 5.3L19.5 19H4.5L12 7.3zM11 10v5h2v-5h-2zm0 6v2h2v-2h-2z"
+                        fill="currentColor"
+                    />
+                </svg>
+            </span>
+            <span class="maintenance-banner__text">
+                Amazon Q Developer is now in maintenance mode. New accounts are no longer available. Existing users can still sign in below.
+                <a class="maintenance-banner__link" href="https://aws.amazon.com/q/developer/" @click="handleLearnMoreClick">Learn more</a>
+            </span>
+        </div>
+        <button
+            class="create-account-button font-amazon bottom-small-gap"
+            type="button"
+            disabled
+            aria-disabled="true"
+            title="New account creation is no longer available"
+            v-if="existingLogin.id === -1"
+        >
+            <span>Create New Account</span>
+            <svg class="create-account-button__lock" width="12" height="12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path
+                    d="M12 1a5 5 0 0 0-5 5v3H6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V11a2 2 0 0 0-2-2h-1V6a5 5 0 0 0-5-5zm-3 5a3 3 0 0 1 6 0v3H9V6z"
+                    fill="currentColor"
+                />
+            </svg>
+        </button>
+        <div class="existing-users-divider font-amazon bottom-small-gap" v-if="existingLogin.id === -1"><span>existing users</span></div>
         <SelectableItem
             @toggle="toggleItemSelection"
             :isSelected="selectedLoginOption === LoginOption.BUILDER_ID"
             :itemId="LoginOption.BUILDER_ID"
             :login-type="LoginOption.BUILDER_ID"
-            :itemTitle="'Use for free'"
-            :itemText="'No AWS account required'"
+            :itemTitle="'Builder ID'"
+            :itemText="'Sign in with your existing Builder ID.'"
             class="font-amazon bottom-small-gap"
         ></SelectableItem>
-        <!-- TODO: IdC description undecided -->
         <SelectableItem
             @toggle="toggleItemSelection"
             :isSelected="selectedLoginOption === LoginOption.ENTERPRISE_SSO"
             :itemId="LoginOption.ENTERPRISE_SSO"
             :login-type="LoginOption.ENTERPRISE_SSO"
-            :itemTitle="'Use with Pro license'"
+            :itemTitle="'Identity Center'"
+            :itemText="'Sign in through your organization\'s IAM Identity Center.'"
             class="font-amazon bottom-small-gap"
         ></SelectableItem>
         <button
@@ -43,7 +74,7 @@
             v-on:click="handleContinueClick()"
             tabindex="-1"
         >
-            Continue
+            Sign in with existing account
         </button>
     </div>
 </template>
@@ -88,6 +119,9 @@ export default defineComponent({
             this.selectedLoginOption = itemId
             window.telemetryApi.postClickEvent(itemId + "Option")
         },
+        handleLearnMoreClick() {
+            window.telemetryApi.postClickEvent("maintenanceLearnMoreLink")
+        },
         handleBackButtonClick() {
             this.$emit('backToMenu')
         },
@@ -128,4 +162,106 @@ export default defineComponent({
 </script>
 
 <style scoped lang="scss">
+.welcome-header {
+    text-align: center;
+}
+
+.maintenance-banner {
+    display: flex;
+    gap: 8px;
+    align-items: flex-start;
+    padding: 10px 12px;
+    border-radius: 5px;
+    background: rgba(234, 179, 8, 0.12);
+    border: 1px solid rgba(234, 179, 8, 0.45);
+    color: #e0b84d;
+    font-size: 12px;
+    line-height: 1.5;
+
+    &__icon {
+        flex-shrink: 0;
+        display: inline-flex;
+        align-items: center;
+        margin-top: 2px;
+        color: inherit;
+    }
+
+    &__text {
+        flex: 1;
+    }
+
+    &__link {
+        color: inherit;
+        text-decoration: underline;
+        cursor: pointer;
+        font-weight: 500;
+    }
+
+    &__link:hover {
+        opacity: 0.85;
+    }
+}
+
+body.jb-light .maintenance-banner {
+    background: rgba(180, 120, 10, 0.08);
+    border-color: rgba(180, 120, 10, 0.55);
+    color: #8a6d1c;
+}
+
+.create-account-button {
+    width: 100%;
+    height: 30px;
+    border: none;
+    border-radius: 4px;
+    font-size: 13px;
+    font-weight: bold;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    background-color: #3a3a3a;
+    color: #8a8a8a;
+    cursor: not-allowed;
+    margin-bottom: 24px !important;
+
+    &__lock {
+        color: currentColor;
+    }
+}
+
+body.jb-light .create-account-button {
+    background-color: #d4d4d4;
+    color: #7a7a7a;
+}
+
+.existing-users-divider {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: #888;
+    font-size: 12px;
+    margin-bottom: 24px !important;
+
+    &::before,
+    &::after {
+        content: '';
+        flex: 1;
+        height: 1px;
+        background: #3c3c3c;
+    }
+
+    span {
+        white-space: nowrap;
+    }
+}
+
+body.jb-light .existing-users-divider {
+    color: #666;
+
+    &::before,
+    &::after {
+        background: #c8c8c8;
+    }
+}
 </style>

--- a/plugin/webview/src/q-ui/components/qOptions.vue
+++ b/plugin/webview/src/q-ui/components/qOptions.vue
@@ -14,7 +14,7 @@
                 </svg>
             </span>
             <span class="maintenance-banner__text">
-                Amazon Q Developer IDE plugins will reach end of support on April 30, 2027. New accounts are no longer available but existing users can still sign in below.
+                Amazon Q Developer IDE plugins will reach end of support on April 30, 2027. New accounts will no longer available starting 5/15, but existing users can still sign-in below.
                 <a class="maintenance-banner__link" href="#" @click.prevent="handleLearnMoreClick">Learn more</a>
             </span>
         </div>

--- a/plugin/webview/src/q-ui/components/qOptions.vue
+++ b/plugin/webview/src/q-ui/components/qOptions.vue
@@ -35,19 +35,16 @@
         </button>
         <div class="existing-users-divider font-amazon bottom-small-gap"><span>existing users</span></div>
 
-        <div class="font-amazon" v-if="existConnections.length > 0">
-            <div class="title bottom-small-gap">Connect with an account:</div>
-            <div v-for="(connection, index) in this.existConnections" :key="index">
-                <SelectableItem
-                    @toggle="toggleItemSelection"
-                    :isSelected="selectedLoginOption === connection.id"
-                    :itemId="connection.id"
-                    :login-type="this.connectionType(connection)"
-                    :itemTitle="this.connectionDisplayedName(connection)"
-                    :itemText="this.connectionTypeDescription(connection)"
-                    class="bottom-small-gap"
-                ></SelectableItem>
-            </div>
+        <div v-if="existConnections.length > 0" v-for="(connection, index) in existConnections" :key="connection.id">
+            <SelectableItem
+                @toggle="toggleItemSelection"
+                :isSelected="selectedLoginOption === connection.id"
+                :itemId="connection.id"
+                :login-type="connectionType(connection)"
+                :itemTitle="connectionDisplayedName(connection)"
+                :itemText="connectionTypeDescription(connection)"
+                class="font-amazon bottom-small-gap"
+            ></SelectableItem>
         </div>
         <SelectableItem
             @toggle="toggleItemSelection"

--- a/plugin/webview/src/q-ui/components/qOptions.vue
+++ b/plugin/webview/src/q-ui/components/qOptions.vue
@@ -30,7 +30,7 @@
             </span>
             <span class="maintenance-banner__text">
                 Amazon Q Developer is now in maintenance mode. New accounts are no longer available. Existing users can still sign in below.
-                <a class="maintenance-banner__link" href="https://aws.amazon.com/q/developer/" @click="handleLearnMoreClick">Learn more</a>
+                <a class="maintenance-banner__link" href="#" @click.prevent="handleLearnMoreClick">Learn more</a>
             </span>
         </div>
         <button
@@ -121,6 +121,10 @@ export default defineComponent({
         },
         handleLearnMoreClick() {
             window.telemetryApi.postClickEvent("maintenanceLearnMoreLink")
+            window.ideApi.postMessage({
+                command: 'openUrl',
+                params: { url: 'https://aws.amazon.com/q/developer/' }
+            })
         },
         handleBackButtonClick() {
             this.$emit('backToMenu')

--- a/plugin/webview/src/q-ui/components/selectableItem.vue
+++ b/plugin/webview/src/q-ui/components/selectableItem.vue
@@ -6,8 +6,8 @@
         <div class="icon">
             <svg
                 v-if="loginType === LoginOption.BUILDER_ID"
-                width="20"
-                height="20"
+                width="16"
+                height="16"
                 viewBox="0 0 16 16"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
@@ -21,8 +21,8 @@
             </svg>
             <svg
                 v-if="loginType === LoginOption.ENTERPRISE_SSO"
-                width="20"
-                height="20"
+                width="16"
+                height="16"
                 viewBox="0 0 16 16"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
@@ -94,10 +94,11 @@ export default defineComponent({
 
 <style scoped lang="scss">
 .item-container {
-    padding: 15px;
+    padding: 10px 12px;
     display: flex;
     align-items: center;
-    height: 38px;
+    min-height: 50px;
+    box-sizing: border-box;
 }
 
 .selected {
@@ -105,6 +106,7 @@ export default defineComponent({
 }
 
 .item-title {
+    font-size: 13px;
     font-weight: bold;
     margin-bottom: 2px;
 }
@@ -112,11 +114,20 @@ export default defineComponent({
 .text {
     display: flex;
     flex-direction: column;
-    font-size: 15px;
+    font-size: 12px;
+    min-width: 0;
+}
+
+.p {
+    line-height: 1.4;
+    white-space: normal;
 }
 
 .icon {
-    margin-right: 15px;
+    margin-right: 11px;
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
 }
 
 /* Theme specific styles */

--- a/plugin/webview/src/q-ui/components/ssoLoginForm.vue
+++ b/plugin/webview/src/q-ui/components/ssoLoginForm.vue
@@ -68,9 +68,41 @@ export default defineComponent({
         app: String
     },
     data() {
+        const info = this.$store.state.lastLoginIdcInfo
         return {
             startUrlRegex: /^https:\/\/(([\w-]+(?:\.gamma)?\.awsapps\.com\/start(?:-beta|-alpha)?[\/#]?)|(start\.(?:us-gov-home|us-gov-east-1\.us-gov-home|us-gov-west-1\.us-gov-home)\.awsapps\.com|start\.(?:home|cn-north-1\.home|cn-northwest-1\.home)\.awsapps\.cn)\/directory\/[\w-]+[\/#]?)$/,
-            issueUrlRegex: /^https:\/\/([\w-]+\.)?identitycenter\.(amazonaws\.com|amazonaws\.com\.cn|us-gov\.amazonaws\.com)\/[\w\/-]+[\/#]?$/
+            issueUrlRegex: /^https:\/\/([\w-]+\.)?identitycenter\.(amazonaws\.com|amazonaws\.com\.cn|us-gov\.amazonaws\.com)\/[\w\/-]+[\/#]?$/,
+            startUrl: info.startUrl || '',
+            selectedRegion: info.region || 'us-east-1'
+        }
+    },
+    // SWT Browser + Vue 3 quirk: the mounted() hook on this component does not fire reliably,
+    // so v-model's initial DOM sync is skipped. Push the persisted Start URL into the input
+    // from created() via $nextTick — that callback runs after Vue's next render flush and
+    // does not depend on the mounted lifecycle hook firing.
+    created() {
+        const expected = this.startUrl
+        if (!expected) return
+        this.$nextTick(() => {
+            const el = document.getElementById("startUrl") as HTMLInputElement | null
+            if (!el || el.value) return  // don't overwrite if user already typed
+            el.value = expected
+            el.dispatchEvent(new Event('input', { bubbles: true }))
+            el.focus()
+        })
+    },
+    watch: {
+        startUrl(value: string) {
+            window.ideClient.updateLastLoginIdcInfo({
+                ...this.$store.state.lastLoginIdcInfo,
+                startUrl: value
+            })
+        },
+        selectedRegion(value: string) {
+            window.ideClient.updateLastLoginIdcInfo({
+                ...this.$store.state.lastLoginIdcInfo,
+                region: value
+            })
         }
     },
     computed: {
@@ -79,7 +111,7 @@ export default defineComponent({
             const otherRegions = this.regions
                 .filter(r => r.id !== 'us-east-1')
                 .sort((a, b) => a.name.localeCompare(b.name));
-                
+
             return usEast1 ? [usEast1, ...otherRegions] : otherRegions;
         },
         regions(): Region[] {
@@ -87,28 +119,6 @@ export default defineComponent({
         },
         feature(): Feature {
             return this.$store.state.feature
-        },
-        startUrl: {
-            get() {
-                return this.$store.state.lastLoginIdcInfo.startUrl;
-            },
-            set(value: string) {
-                window.ideClient.updateLastLoginIdcInfo({
-                    ...this.$store.state.lastLoginIdcInfo,
-                    startUrl: value
-                })
-            }
-        },
-        selectedRegion: {
-            get() {
-                return this.$store.state.lastLoginIdcInfo.region;
-            },
-            set(value: string) {
-                window.ideClient.updateLastLoginIdcInfo({
-                    ...this.$store.state.lastLoginIdcInfo,
-                    region: value
-                })
-            }
         },
         isStartUrlValid: {
             get() {
@@ -152,9 +162,6 @@ export default defineComponent({
         handleCodeCatalystSignin() {
             this.$emit('login', new BuilderId())
         }
-    },
-    mounted() {
-        document.getElementById("startUrl")?.focus()
     }
 })
 </script>


### PR DESCRIPTION
## Summary


<img width="1506" height="857" alt="image" src="https://github.com/user-attachments/assets/666060ee-a8c6-45b7-8bf8-7445cabac617" />



## Test plan

- [ ] Build the Eclipse plugin and open the Amazon Q sign-in view
- [ ] Verify: "Welcome to Amazon Q" centered header, yellow maintenance banner with Learn-more link
- [ ] Verify: Create-New-Account button renders gray/disabled with lock icon and is not clickable
- [ ] Verify: Builder ID / Identity Center cards show new titles; Identity Center description wraps cleanly (no truncation)
- [ ] Verify: primary button reads "Sign in with existing account"; Builder ID and Identity Center flows still route correctly
- [ ] Toggle dark / light themes — colors stay legible
- [ ] Smoke-test the SSO form, AWS profile form, reauth, and profile-selection pages — no regressions from the common.scss size reductions