### PR TITLE
feat(notifications): add startup toast for KTLO message broadcast

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/LspStartupActivity.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/LspStartupActivity.java
@@ -26,6 +26,7 @@ import software.aws.toolkits.eclipse.amazonq.util.AutoTriggerDocumentListener;
 import software.aws.toolkits.eclipse.amazonq.util.AutoTriggerPartListener;
 import software.aws.toolkits.eclipse.amazonq.util.AutoTriggerTopLevelListener;
 import software.aws.toolkits.eclipse.amazonq.util.Constants;
+import software.aws.toolkits.eclipse.amazonq.util.KiroSunsetNotification;
 import software.aws.toolkits.eclipse.amazonq.util.ThreadingUtils;
 import software.aws.toolkits.eclipse.amazonq.util.ToolkitNotification;
 import software.aws.toolkits.eclipse.amazonq.util.UpdateUtils;
@@ -80,8 +81,20 @@ public class LspStartupActivity implements IStartup {
                 Display.getDefault().asyncExec(() -> launchWebview());
             }
             Display.getDefault().asyncExec(() -> attachAutoTriggerListenersIfApplicable());
+            Display.getDefault().asyncExec(() -> showKiroSunsetNotification());
             checkForUpdates();
         });
+    }
+
+    private void showKiroSunsetNotification() {
+        if (Activator.getPluginStore().get(Constants.KIRO_SUNSET_NOTIFICATION_DISMISSED_KEY) != null) {
+            return;
+        }
+        AbstractNotificationPopup notification = new KiroSunsetNotification(Display.getCurrent(),
+                Constants.KIRO_SUNSET_NOTIFICATION_TITLE,
+                Constants.KIRO_SUNSET_NOTIFICATION_BODY,
+                () -> Activator.getPluginStore().put(Constants.KIRO_SUNSET_NOTIFICATION_DISMISSED_KEY, "true"));
+        notification.open();
     }
 
     private void checkForUpdates() {

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
@@ -44,6 +44,11 @@ public final class Constants {
     public static final String TELEMETRY_NOTIFICATION_TITLE = "AWS IDE plugins telemetry";
     public static final String TELEMETRY_NOTIFICATION_BODY = "Usage metrics are collected by default. This can be changed in the \"Amazon Q\" section"
             + " of the IDE preferences.";
+    public static final String KIRO_SUNSET_NOTIFICATION_TITLE = "Amazon Q Developer is transitioning to Kiro";
+    public static final String KIRO_SUNSET_NOTIFICATION_BODY = "Amazon Q Developer is now in maintenance mode. The next generation of the agentic"
+            + " coding experience is available in Kiro.";
+    public static final String KIRO_SUNSET_LEARN_MORE_URL = "https://kiro.dev";
+    public static final String KIRO_SUNSET_NOTIFICATION_DISMISSED_KEY = "kiroSunsetNotificationDismissed";
     public static final String RE_AUTHENTICATE_FAILURE_MESSAGE = "An error occurred while attempting to re-authenticate. Please try again.";
     public static final String AUTHENTICATE_FAILURE_MESSAGE = "An error occurred while attempting to authenticate. Please try again.";
     public static final String IDE_SSL_HANDSHAKE_TITLE = "SSL Handshake Error";

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java
@@ -40,10 +40,10 @@ public final class Constants {
     public static final String TELEMETRY_NOTIFICATION_TITLE = "AWS IDE plugins telemetry";
     public static final String TELEMETRY_NOTIFICATION_BODY = "Usage metrics are collected by default. This can be changed in the \"Amazon Q\" section"
             + " of the IDE preferences.";
-    public static final String KIRO_SUNSET_NOTIFICATION_TITLE = "Amazon Q Developer is transitioning to Kiro";
-    public static final String KIRO_SUNSET_NOTIFICATION_BODY = "Amazon Q Developer is now in maintenance mode. The next generation of the agentic"
-            + " coding experience is available in Kiro.";
-    public static final String KIRO_SUNSET_LEARN_MORE_URL = "https://kiro.dev";
+    public static final String KIRO_SUNSET_NOTIFICATION_TITLE = "Amazon Q Developer end of support";
+    public static final String KIRO_SUNSET_NOTIFICATION_BODY = "Amazon Q Developer IDE plugins will reach end of support on April 30, 2027."
+            + " New accounts will no longer available starting 5/15, but existing users can still sign-in below.";
+    public static final String KIRO_SUNSET_LEARN_MORE_URL = "https://aws.amazon.com/q/developer/";
     public static final String KIRO_SUNSET_NOTIFICATION_DISMISSED_KEY = "kiroSunsetNotificationDismissed";
     public static final String RE_AUTHENTICATE_FAILURE_MESSAGE = "An error occurred while attempting to re-authenticate. Please try again.";
     public static final String AUTHENTICATE_FAILURE_MESSAGE = "An error occurred while attempting to authenticate. Please try again.";

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/KiroSunsetNotification.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/KiroSunsetNotification.java
@@ -1,0 +1,64 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.eclipse.amazonq.util;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+
+public final class KiroSunsetNotification extends ToolkitNotification {
+
+    private final Runnable onDismiss;
+
+    public KiroSunsetNotification(final Display display, final String title,
+            final String description, final Runnable onDismiss) {
+        super(display, title, description);
+        this.onDismiss = onDismiss;
+    }
+
+    @Override
+    protected void createContentArea(final Composite parent) {
+        super.createContentArea(parent);
+
+        Composite buttonRow = new Composite(parent, SWT.NONE);
+        GridLayout layout = new GridLayout(2, false);
+        layout.marginWidth = 0;
+        layout.marginHeight = 0;
+        buttonRow.setLayout(layout);
+        buttonRow.setLayoutData(new GridData(SWT.END, SWT.CENTER, true, false));
+
+        Button learnMoreButton = new Button(buttonRow, SWT.PUSH);
+        learnMoreButton.setText("Learn more");
+        learnMoreButton.setLayoutData(new GridData(SWT.END, SWT.CENTER, false, false));
+        learnMoreButton.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(final SelectionEvent e) {
+                PluginUtils.openWebpage(Constants.KIRO_SUNSET_LEARN_MORE_URL);
+                dismiss();
+            }
+        });
+
+        Button dismissButton = new Button(buttonRow, SWT.PUSH);
+        dismissButton.setText("Dismiss");
+        dismissButton.setLayoutData(new GridData(SWT.END, SWT.CENTER, false, false));
+        dismissButton.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(final SelectionEvent e) {
+                dismiss();
+            }
+        });
+    }
+
+    private void dismiss() {
+        if (onDismiss != null) {
+            onDismiss.run();
+        }
+        close();
+    }
+}


### PR DESCRIPTION
## Summary
Add a toast UI for notifying customers about amazon-q's sunset

<img width="581" height="807" alt="image" src="https://github.com/user-attachments/assets/0bbefa0d-ab82-47bf-8f05-7d6464f04dff" />


### Files

- `plugin/src/software/aws/toolkits/eclipse/amazonq/util/KiroSunsetNotification.java` — new class with the Dismiss / Learn more buttons.
- `plugin/src/software/aws/toolkits/eclipse/amazonq/util/Constants.java` — title, body, URL, and dismissal-key strings.
- `plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/LspStartupActivity.java` — schedules `showKiroSunsetNotification()` on the UI thread during post-startup.



