### PR TITLE
ci: upload plugin JAR and update site as build artifacts

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,12 +1,9 @@
-# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+# This workflow builds the Eclipse plugin with Maven/Tycho and uploads
+# the plugin JAR and p2 update site as downloadable artifacts.
+#
+# Artifacts are available from the Actions tab on every PR and main push.
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-name: Maven Sanity Build
+name: Maven Build
 
 on:
   push:
@@ -14,17 +11,16 @@ on:
   pull_request:
     branches: [ "main", "feature/*" ]
 
-
 permissions:
   contents: read
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Setup Maven Action
       uses: s4u/setup-maven-action@v1.18.0
       with:
@@ -32,5 +28,24 @@ jobs:
         java-version: 17
         java-distribution: temurin
         maven-version: 3.9.8
+
     - name: Build with Maven
       run: mvn -B package --file pom.xml
+
+    - name: Upload plugin JAR
+      if: success()
+      uses: actions/upload-artifact@v4
+      with:
+        name: amazon-q-eclipse-plugin
+        path: plugin/target/amazon-q-eclipse-*.jar
+        if-no-files-found: error
+        retention-days: 30
+
+    - name: Upload update site
+      if: success()
+      uses: actions/upload-artifact@v4
+      with:
+        name: amazon-q-eclipse-update-site
+        path: updatesite/target/amazon-q-eclipse-update-site-*.zip
+        if-no-files-found: error
+        retention-days: 30


### PR DESCRIPTION
## What

Add `upload-artifact` steps to the existing Maven build workflow so the plugin JAR and p2 update site ZIP are downloadable from the GitHub Actions tab.

## Changes

- `maven.yml`: Added two `actions/upload-artifact@v4` steps after the Maven build
  - `amazon-q-eclipse-plugin` — the plugin JAR (`plugin/target/amazon-q-eclipse-*.jar`)
  - `amazon-q-eclipse-update-site` — the p2 update site ZIP (`updatesite/target/amazon-q-eclipse-update-site-*.zip`)
- Artifacts are uploaded on every successful build (PRs and main pushes)
- 30-day retention
- Renamed workflow from "Maven Sanity Build" to "Maven Build"

## How to use

1. Open any PR or main push in the Actions tab
2. Click the completed workflow run
3. Scroll to "Artifacts" at the bottom
4. Download `amazon-q-eclipse-plugin` (the JAR) or `amazon-q-eclipse-update-site` (the ZIP)

**To install the JAR:** drop it into your Eclipse `dropins/` folder and restart.

**To install from the update site:** unzip, then `Help → Install New Software → Add → Local` pointing at the unzipped directory.

## Testing

This PR itself will trigger the workflow — check the Actions tab after CI runs to verify artifacts appear.
