### PR TITLE
fix: prevent Learn More from suppressing sunset toast and fix popup clipping

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,12 +1,9 @@
-# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+# This workflow builds the Eclipse plugin with Maven/Tycho and uploads
+# the plugin JAR and p2 update site as downloadable artifacts.
+#
+# Artifacts are available from the Actions tab on every PR and main push.
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-name: Maven Sanity Build
+name: Maven Build
 
 on:
   push:
@@ -14,17 +11,16 @@ on:
   pull_request:
     branches: [ "main", "feature/*" ]
 
-
 permissions:
   contents: read
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Setup Maven Action
       uses: s4u/setup-maven-action@v1.18.0
       with:
@@ -32,5 +28,24 @@ jobs:
         java-version: 17
         java-distribution: temurin
         maven-version: 3.9.8
+
     - name: Build with Maven
       run: mvn -B package --file pom.xml
+
+    - name: Upload plugin JAR
+      if: success()
+      uses: actions/upload-artifact@v4
+      with:
+        name: amazon-q-eclipse-plugin
+        path: plugin/target/amazon-q-eclipse-*.jar
+        if-no-files-found: error
+        retention-days: 30
+
+    - name: Upload update site
+      if: success()
+      uses: actions/upload-artifact@v4
+      with:
+        name: amazon-q-eclipse-update-site
+        path: updatesite/target/amazon-q-eclipse-update-site-*.zip
+        if-no-files-found: error
+        retention-days: 30

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/KiroSunsetNotification.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/KiroSunsetNotification.java
@@ -40,7 +40,7 @@ public final class KiroSunsetNotification extends ToolkitNotification {
             @Override
             public void widgetSelected(final SelectionEvent e) {
                 PluginUtils.openWebpage(Constants.KIRO_SUNSET_LEARN_MORE_URL);
-                dismiss();
+                close();
             }
         });
 

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/ToolkitNotification.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/ToolkitNotification.java
@@ -72,9 +72,9 @@ public class ToolkitNotification extends AbstractNotificationPopup {
     @Override
     protected final void initializeBounds() {
         Rectangle clArea = getPrimaryClientArea();
-        Point initialSize = getShell().computeSize(SWT.DEFAULT, SWT.DEFAULT);
-        int height = Math.max(initialSize.y, MIN_HEIGHT);
-        int width = Math.min(initialSize.x, MAX_WIDTH);
+        int width = Math.min(getShell().computeSize(SWT.DEFAULT, SWT.DEFAULT).x, MAX_WIDTH);
+        // Recompute height with the constrained width so wrapped text and buttons are accounted for
+        int height = Math.max(getShell().computeSize(width, SWT.DEFAULT).y, MIN_HEIGHT);
         Point size = new Point(width, height);
         // Calculate the position for the new notification
         int x = clArea.x + clArea.width - size.x - PADDING_EDGE;


### PR DESCRIPTION
## Summary

Two fixes for thesunset notification toast (PR #545):

1. **Learn More no longer suppresses future notifications** — clicking "Learn More" previously called `dismiss()` which persisted the `kiroSunsetNotificationDismissed` key. Now it only opens the URL. The notification will reappear on next Eclipse launch until the user explicitly clicks "Dismiss".

2. **Fix notification popup height clipping** — the button row (Learn More / Dismiss) was cut off because `initializeBounds()` computed height with unconstrained width (`computeSize(SWT.DEFAULT, SWT.DEFAULT)`). Since the popup is capped at `MAX_WIDTH=400`, text wraps and the actual height is taller than the unconstrained estimate. Now computes height with the constrained width so the layout engine accounts for wrapping + buttons.

## Testing

- Built and installed via dropins
- Verified notification shows on every Eclipse launch until Dismiss is clicked
- Verified Learn More opens the correct URL without suppressing future appearances
- Verified buttons are fully visible (no clipping)
