### PR TITLE
Status: Open. #560: Filepath issue fix.

### DIFF
--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/assets/ChatWebViewAssetProvider.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/providers/assets/ChatWebViewAssetProvider.java
@@ -425,7 +425,7 @@ public final class ChatWebViewAssetProvider extends WebViewAssetProvider {
 
         String jsFile = Paths.get(chatUiDirectory.get()).resolve("amazonq-ui.js").toString();
         var jsParent = Path.of(jsFile).getParent();
-        var jsDirectoryPath = Path.of(jsParent.toUri()).normalize().toString();
+        var jsDirectoryPath = jsParent.normalize().toString();
 
         if (webviewAssetServer == null) {
             webviewAssetServer = new WebviewAssetServer();

--- a/plugin/src/software/aws/toolkits/eclipse/amazonq/util/WebviewAssetServer.java
+++ b/plugin/src/software/aws/toolkits/eclipse/amazonq/util/WebviewAssetServer.java
@@ -3,6 +3,8 @@
 
 package software.aws.toolkits.eclipse.amazonq.util;
 
+import java.nio.file.Path;
+
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ResourceHandler;
@@ -29,7 +31,7 @@ public final class WebviewAssetServer {
             var handler = new ResourceHandler();
 
             ResourceFactory resourceFactory = ResourceFactory.of(server);
-            handler.setBaseResource(resourceFactory.newResource(jsPath));
+            handler.setBaseResource(resourceFactory.newResource(Path.of(jsPath)));
             handler.setDirAllowed(true);
             servletContext.setHandler(handler);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Amazon q Plugin was showing blank script with error:

Caused by: java.nio.file.InvalidPathException: Illegal char <:> at index 2: /C:/Users/sxs09221/eclipse-workspace/.metadata/.plugins/amazon-q-eclipse/lsp/AmazonQAgentic/1.70.0/clients/amazonq-ui.js
at java.base/sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:204)
at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:175)
at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
at java.base/sun.nio.fs.WindowsPath.parse(WindowsPath.java:92)
at java.base/sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:231)
at java.base/java.nio.file.Path.resolve(Path.java:516)
at org.eclipse.jetty.util.resource.PathResource.resolveSchemeSpecificPath(PathResource.java:315)
at org.eclipse.jetty.util.resource.PathResource.resolve(PathResource.java:296)
at org.eclipse.jetty.http.content.ResourceHttpContentFactory.resolve(ResourceHttpContentFactory.java:82)
at org.eclipse.jetty.http.content.ResourceHttpContentFactory.getContent(ResourceHttpContentFactory.java:54)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
