### PR TITLE
chore: bump version to 2.7.5

### DIFF
--- a/feature/feature.xml
+++ b/feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="software.aws.toolkits.eclipse.amazonq.feature"
       label="Amazon Q for Eclipse"
-      version="2.7.4.qualifier">
+      version="2.7.5.qualifier">
 
    <description>
       Amazon Q Developer helps users build faster across the entire software development lifecycle by providing tailored responses and code recommendations that conform to their team's internal libraries, proprietary algorithmic techniques, and enterprise code style.
@@ -198,6 +198,6 @@ https://github.com/aws/amazon-q-eclipse/blob/main/attribution.xml
          id="amazon-q-eclipse"
          download-size="11000"
          install-size="0"
-         version="2.7.4.qualifier"
+         version="2.7.5.qualifier"
          unpack="false"/>
 </feature>

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>software.aws.toolkits.eclipse</groupId>
     <artifactId>amazon-q-eclipse-group</artifactId>
-    <version>2.7.4-SNAPSHOT</version>
+    <version>2.7.5-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Amazon Q for Eclipse
 Bundle-Provider: Amazon Web Services
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-SymbolicName: amazon-q-eclipse;singleton:=true
-Bundle-Version: 2.7.4.qualifier
+Bundle-Version: 2.7.5.qualifier
 Automatic-Module-Name: amazon.q.eclipse
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: software.aws.toolkits.eclipse.amazonq.plugin.Activator

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>software.aws.toolkits.eclipse</groupId>
         <artifactId>amazon-q-eclipse-group</artifactId>
-        <version>2.7.4-SNAPSHOT</version>
+        <version>2.7.5-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>software.aws.toolkits.eclipse</groupId>
     <artifactId>amazon-q-eclipse-group</artifactId>
-    <version>2.7.4-SNAPSHOT</version>
+    <version>2.7.5-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/telemetry/pom.xml
+++ b/telemetry/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>software.aws.toolkits.eclipse</groupId>
         <artifactId>amazon-q-eclipse-group</artifactId>
-        <version>2.7.4-SNAPSHOT</version>
+        <version>2.7.5-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/updatesite/category.xml
+++ b/updatesite/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/software.aws.toolkits.eclipse.amazonq.feature_2.7.4.qualifier.jar" id="software.aws.toolkits.eclipse.amazonq.feature" version="2.7.4.qualifier">
+   <feature url="features/software.aws.toolkits.eclipse.amazonq.feature_2.7.5.qualifier.jar" id="software.aws.toolkits.eclipse.amazonq.feature" version="2.7.5.qualifier">
       <category name="software.aws.toolkits.eclipse.amazonq"/>
    </feature>
    <category-def name="software.aws.toolkits.eclipse.amazonq" label="software.aws.toolkits.eclipse">

--- a/updatesite/pom.xml
+++ b/updatesite/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>software.aws.toolkits.eclipse</groupId>
     <artifactId>amazon-q-eclipse-group</artifactId>
-    <version>2.7.4-SNAPSHOT</version>
+    <version>2.7.5-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 


### PR DESCRIPTION
Bumps the plugin version from 2.7.4 to 2.7.5 in preparation for the next release (MCM-155149058).

Updates the version string across all module descriptors:
- `pom.xml`, `feature/pom.xml`, `plugin/pom.xml`, `telemetry/pom.xml`, `updatesite/pom.xml`
- `feature/feature.xml` (feature + plugin version)
- `plugin/META-INF/MANIFEST.MF` (Bundle-Version)
- `updatesite/category.xml` (feature url + version)

Mirrors the prior bump commit eeba95a (#564).